### PR TITLE
Improve arXiv SuperPOD batch delivery validation

### DIFF
--- a/scripts/superpod-job.py
+++ b/scripts/superpod-job.py
@@ -395,11 +395,42 @@ def derive_default_output_dir(site):
     return f"./{slug}-processed"
 
 
-def write_json(path, data):
-    """Write JSON with reasonable formatting."""
-    with open(path, "w") as f:
+def write_json(path, data, *, verbose=True):
+    """Write JSON atomically with reasonable formatting."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False)
-    print(f"       Written {path} ({os.path.getsize(path) / 1e6:.1f} MB)")
+    tmp.replace(path)
+    if verbose:
+        print(f"       Written {path} ({os.path.getsize(path) / 1e6:.1f} MB)")
+
+
+def read_json_if_exists(path):
+    """Return parsed JSON or None when the file is absent/unreadable."""
+    path = Path(path)
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def stage_status_dir(outdir):
+    return Path(outdir) / "stage-status"
+
+
+def stage_status_path(outdir, stage_key):
+    return stage_status_dir(outdir) / f"{stage_key}.json"
+
+
+def write_stage_status(outdir, stage_key, record):
+    write_json(stage_status_path(outdir, stage_key), record, verbose=False)
+
+
+def read_stage_status(outdir, stage_key):
+    return read_json_if_exists(stage_status_path(outdir, stage_key))
 
 
 # --- Stage 5: NER term spotting + scope detection (CPU, classical) ---
@@ -1604,6 +1635,16 @@ def _is_arxiv_entry_id(entry_id) -> bool:
     return str(entry_id or "").startswith("arxiv-")
 
 
+_STAGE3_ARXIV_PARSE_VERSION = "arxiv-paper-shapes-v2"
+_STAGE3_SE_PARSE_VERSION = "se-patterns-v1"
+
+
+def _stage3_parse_version(entry_ids) -> str:
+    if any(_is_arxiv_entry_id(entry_id) for entry_id in entry_ids):
+        return _STAGE3_ARXIV_PARSE_VERSION
+    return _STAGE3_SE_PARSE_VERSION
+
+
 def _stage3_prompt_for_entry(entry_id, question_title, question_text, answer_text):
     if _is_arxiv_entry_id(entry_id):
         return build_arxiv_pattern_prompt(
@@ -1656,6 +1697,94 @@ def _stage3_result_from_raw(entry_id, raw):
     }
 
 
+def _can_reparse_stage3_chunks(existing_meta, expected_meta):
+    """True when only the parser version changed, not the LLM chunk geometry."""
+    if not isinstance(existing_meta, dict):
+        return False
+    old = dict(existing_meta)
+    new = dict(expected_meta)
+    old_parse_version = old.pop("parse_version", None)
+    new_parse_version = new.pop("parse_version", None)
+    return old == new and old_parse_version != new_parse_version
+
+
+def _reparse_stage3_chunks_from_raw(chunk_ranges, chunk_dir, entry_ids, expected_meta):
+    reparsed_total = 0
+    failed_total = 0
+    for chunk_idx, start, end in chunk_ranges:
+        chunk_path = chunk_dir / f"chunk-{chunk_idx:03d}.json"
+        if not chunk_path.exists():
+            raise RuntimeError(
+                f"Cannot reparse Stage 3 chunk with current parser: {chunk_path} "
+                "is missing. Remove stage3-pattern-tags-chunks to restart Stage 3."
+            )
+        with open(chunk_path) as f:
+            chunk_data = json.load(f)
+        if not isinstance(chunk_data, list):
+            raise RuntimeError(
+                f"Cannot reparse Stage 3 chunk with current parser: "
+                f"{chunk_path} is not a JSON list."
+            )
+        expected_len = end - start
+        if len(chunk_data) != expected_len:
+            raise RuntimeError(
+                f"Cannot reparse Stage 3 chunk with current parser: {chunk_path} "
+                f"has {len(chunk_data)} rows, expected {expected_len}."
+            )
+
+        reparsed_rows = []
+        for offset, old_row in enumerate(chunk_data):
+            if not isinstance(old_row, dict) or "raw" not in old_row:
+                raise RuntimeError(
+                    f"Cannot reparse Stage 3 chunk with current parser: "
+                    f"{chunk_path} row {offset} has no raw LLM response."
+                )
+            new_row = _stage3_result_from_raw(
+                entry_ids[start + offset],
+                old_row.get("raw"),
+            )
+            reparsed_rows.append(new_row)
+            reparsed_total += 1
+            if new_row.get("status") != "ok":
+                failed_total += 1
+
+        tmp_path = chunk_dir / f"chunk-{chunk_idx:03d}.reparse.tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(reparsed_rows, f, ensure_ascii=False)
+        os.replace(tmp_path, chunk_path)
+
+    with open(chunk_dir / "meta.json", "w") as f:
+        json.dump(expected_meta, f, ensure_ascii=False, indent=2)
+    print(
+        "       Reparsed existing Stage 3 chunks with current parser: "
+        f"{reparsed_total - failed_total}/{reparsed_total} ok"
+    )
+
+
+def _shutdown_dataloader_workers(loader, iterator=None):
+    """Best-effort shutdown for multiprocessing DataLoader workers.
+
+    Long-lived local LLM worker processes create several DataLoader-backed
+    inference passes per job. Relying on interpreter shutdown to reap those
+    worker processes leaks multiprocessing semaphores and produces noisy
+    `resource_tracker` warnings at process exit.
+    """
+    target = iterator
+    if target is None and loader is not None:
+        target = getattr(loader, "_iterator", None)
+    shutdown = getattr(target, "_shutdown_workers", None)
+    if callable(shutdown):
+        try:
+            shutdown()
+        except Exception:
+            pass
+    if loader is not None and hasattr(loader, "_iterator"):
+        try:
+            loader._iterator = None
+        except Exception:
+            pass
+
+
 class _DatasetTextGenerationRunner:
     """Dataset/DataLoader-backed text generation without HF Pipeline.__call__.
 
@@ -1697,23 +1826,27 @@ class _DatasetTextGenerationRunner:
             num_workers=num_workers,
             collate_fn=_collate,
         )
-
-        outputs = []
-        device = self._input_device()
-        is_encoder_decoder = bool(
-            getattr(self.config, "is_encoder_decoder", False)
-        )
-        for prompt_batch in loader:
-            decoded = self._generate_prompt_batch(
-                prompt_batch,
-                max_new_tokens=max_new_tokens,
-                return_full_text=return_full_text,
-                is_encoder_decoder=is_encoder_decoder,
+        loader_iter = None
+        try:
+            outputs = []
+            device = self._input_device()
+            is_encoder_decoder = bool(
+                getattr(self.config, "is_encoder_decoder", False)
             )
-            outputs.extend(
-                [{"generated_text": text.strip()}] for text in decoded
-            )
-        return outputs
+            loader_iter = iter(loader)
+            for prompt_batch in loader_iter:
+                decoded = self._generate_prompt_batch(
+                    prompt_batch,
+                    max_new_tokens=max_new_tokens,
+                    return_full_text=return_full_text,
+                    is_encoder_decoder=is_encoder_decoder,
+                )
+                outputs.extend(
+                    [{"generated_text": text.strip()}] for text in decoded
+                )
+            return outputs
+        finally:
+            _shutdown_dataloader_workers(loader, loader_iter)
 
     def _empty_cuda_cache(self):
         try:
@@ -1882,6 +2015,7 @@ def _llm_worker_main(argv):
     parser.add_argument("--batch-size", type=int, required=True)
     parser.add_argument("--loader-workers", type=int, default=0)
     parser.add_argument("--max-input-chars", type=int, required=True)
+    parser.add_argument("--stage3-max-new-tokens", type=int, default=64)
     args = parser.parse_args(argv)
 
     with contextlib.redirect_stdout(sys.stderr):
@@ -1901,6 +2035,9 @@ def _llm_worker_main(argv):
         task_batch_size = int(msg.get("batch_size", args.batch_size))
         try:
             if task_type == "stage3":
+                task_max_new_tokens = int(
+                    msg.get("max_new_tokens", args.stage3_max_new_tokens)
+                )
                 prompts = [
                     _stage3_prompt_for_entry(
                         item["entry_id"],
@@ -1915,7 +2052,7 @@ def _llm_worker_main(argv):
                         prompts,
                         pipe=pipe,
                         tokenizer=tokenizer,
-                        max_new_tokens=64,
+                        max_new_tokens=task_max_new_tokens,
                         batch_size=task_batch_size,
                         loader_workers=args.loader_workers,
                     )
@@ -2033,6 +2170,7 @@ class _LlmGpuPool:
         batch_size: int,
         total_loader_workers: int,
         max_input_chars: int,
+        stage3_max_new_tokens: int = 64,
     ):
         if not gpu_devices:
             raise ValueError("gpu_devices must be non-empty")
@@ -2041,6 +2179,7 @@ class _LlmGpuPool:
         self.batch_size = int(batch_size)
         self.loader_workers = max(0, int(total_loader_workers) // len(gpu_devices))
         self.max_input_chars = int(max_input_chars)
+        self.stage3_max_new_tokens = int(stage3_max_new_tokens)
         self.procs = []
         self.next_task_id = 0
 
@@ -2062,6 +2201,8 @@ class _LlmGpuPool:
                 str(self.loader_workers),
                 "--max-input-chars",
                 str(self.max_input_chars),
+                "--stage3-max-new-tokens",
+                str(self.stage3_max_new_tokens),
             ]
             proc = subprocess.Popen(
                 cmd,
@@ -2157,7 +2298,12 @@ class _LlmGpuPool:
         return out
 
     def run_stage3(self, items: list[dict], batch_size: int) -> list[dict]:
-        return self.run("stage3", items, batch_size=batch_size)
+        return self.run(
+            "stage3",
+            items,
+            batch_size=batch_size,
+            max_new_tokens=self.stage3_max_new_tokens,
+        )
 
     def run_stage5c(self, texts: list[str], batch_size: int) -> list[list[TechniqueHit]]:
         payload = self.run("stage5c", texts, batch_size=batch_size)
@@ -2219,6 +2365,7 @@ def tag_patterns_llm_batch(
     progress_done_base=0,
     progress_total=None,
     progress_start_time=None,
+    max_new_tokens=64,
 ):
     """Tag QA pairs with reasoning patterns using a local LLM.
 
@@ -2272,7 +2419,7 @@ def tag_patterns_llm_batch(
     outputs = pipe(
         prompt_dataset,
         return_full_text=False,
-        max_new_tokens=64,
+        max_new_tokens=max_new_tokens,
         batch_size=batch_size,
         num_workers=loader_workers,
     )
@@ -2323,6 +2470,73 @@ def _stage3_chunk_ranges(total_items, chunks_per_shard):
     return ranges
 
 
+def _fixed_chunk_ranges(total_items, chunk_size):
+    """Return fixed-size [start, end) ranges for resumable chunking."""
+    if total_items <= 0:
+        return []
+    size = max(1, int(chunk_size))
+    ranges = []
+    start = 0
+    chunk_idx = 0
+    while start < total_items:
+        end = min(total_items, start + size)
+        ranges.append((chunk_idx, start, end))
+        start = end
+        chunk_idx += 1
+    return ranges
+
+
+def _all_chunk_files_present(chunk_ranges, chunk_dir):
+    return all(
+        (chunk_dir / f"chunk-{chunk_idx:03d}.json").exists()
+        for chunk_idx, _start, _end in chunk_ranges
+    )
+
+
+def _stage3_expected_meta(total, entry_ids, chunks_per_shard, max_new_tokens):
+    return {
+        "version": 1,
+        "total_pairs": total,
+        "chunks_per_shard": int(chunks_per_shard),
+        "effective_chunks": len(_stage3_chunk_ranges(total, chunks_per_shard)),
+        "max_new_tokens": int(max_new_tokens),
+        "parse_version": _stage3_parse_version(entry_ids),
+    }
+
+
+def _stage3_chunks_available_for_resume(
+    outdir,
+    entry_ids,
+    chunks_per_shard,
+    max_new_tokens,
+):
+    total = len(entry_ids)
+    chunk_ranges = _stage3_chunk_ranges(total, chunks_per_shard)
+    if not chunk_ranges:
+        return True
+    chunk_dir = outdir / "stage3-pattern-tags-chunks"
+    meta_path = chunk_dir / "meta.json"
+    if not meta_path.exists():
+        return False
+    try:
+        with open(meta_path) as f:
+            existing_meta = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    expected_meta = _stage3_expected_meta(
+        total,
+        entry_ids,
+        chunks_per_shard,
+        max_new_tokens,
+    )
+    if (
+        existing_meta != expected_meta
+        and not _can_reparse_stage3_chunks(existing_meta, expected_meta)
+    ):
+        return False
+    return _all_chunk_files_present(chunk_ranges, chunk_dir)
+
+
 def run_stage3_pattern_tagging_chunked(
     pairs,
     entry_ids,
@@ -2333,6 +2547,7 @@ def run_stage3_pattern_tagging_chunked(
     chunks_per_shard=10,
     loader_workers=0,
     llm_pool=None,
+    max_new_tokens=64,
 ):
     """Run Stage 3 in resumable chunks and merge to pattern-tags.json.
 
@@ -2348,21 +2563,29 @@ def run_stage3_pattern_tagging_chunked(
     chunk_dir.mkdir(parents=True, exist_ok=True)
 
     meta_path = chunk_dir / "meta.json"
-    expected_meta = {
-        "version": 1,
-        "total_pairs": total,
-        "chunks_per_shard": int(chunks_per_shard),
-        "effective_chunks": len(chunk_ranges),
-    }
+    expected_meta = _stage3_expected_meta(
+        total,
+        entry_ids,
+        chunks_per_shard,
+        max_new_tokens,
+    )
     if meta_path.exists():
         with open(meta_path) as f:
             existing_meta = json.load(f)
         if existing_meta != expected_meta:
-            raise RuntimeError(
-                f"Stage 3 chunk metadata mismatch in {meta_path}. "
-                "Remove stage3-pattern-tags-chunks to restart Stage 3 chunking "
-                "with new parameters."
-            )
+            if _can_reparse_stage3_chunks(existing_meta, expected_meta):
+                _reparse_stage3_chunks_from_raw(
+                    chunk_ranges,
+                    chunk_dir,
+                    entry_ids,
+                    expected_meta,
+                )
+            else:
+                raise RuntimeError(
+                    f"Stage 3 chunk metadata mismatch in {meta_path}. "
+                    "Remove stage3-pattern-tags-chunks to restart Stage 3 "
+                    "chunking with new parameters."
+                )
     else:
         with open(meta_path, "w") as f:
             json.dump(expected_meta, f, ensure_ascii=False, indent=2)
@@ -2372,7 +2595,7 @@ def run_stage3_pattern_tagging_chunked(
         return []
 
     print(f"       Stage 3 chunking: {len(chunk_ranges)} chunks "
-          f"(requested={chunks_per_shard})")
+          f"(requested={chunks_per_shard}, max_new_tokens={max_new_tokens})")
 
     pending_chunks = []
     completed_pairs = 0
@@ -2424,6 +2647,7 @@ def run_stage3_pattern_tagging_chunked(
                 progress_done_base=processed_this_run,
                 progress_total=remaining_pairs,
                 progress_start_time=run_start,
+                max_new_tokens=max_new_tokens,
             )
         processed_this_run += chunk_size
 
@@ -2785,6 +3009,33 @@ def _build_stage6_result(entity_id, question_id, raw_text):
     return record
 
 
+def _stage6_expected_meta(total, chunks_per_shard):
+    return {
+        "version": 2,
+        "total_pairs": total,
+        "chunks_per_shard": int(chunks_per_shard),
+        "effective_chunks": len(_stage3_chunk_ranges(total, chunks_per_shard)),
+    }
+
+
+def _stage6_chunks_available_for_resume(outdir, total, chunks_per_shard):
+    chunk_ranges = _stage3_chunk_ranges(total, chunks_per_shard)
+    if not chunk_ranges:
+        return True
+    chunk_dir = outdir / "stage6-reverse-morphogenesis-chunks"
+    meta_path = chunk_dir / "meta.json"
+    if not meta_path.exists():
+        return False
+    try:
+        with open(meta_path) as f:
+            existing_meta = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    if existing_meta != _stage6_expected_meta(total, chunks_per_shard):
+        return False
+    return _all_chunk_files_present(chunk_ranges, chunk_dir)
+
+
 def _parse_json_array_response(text):
     """Extract a JSON array from LLM response text."""
     start = text.find('[')
@@ -2921,12 +3172,7 @@ def run_stage6_reverse_morphogenesis_chunked(
     chunk_dir.mkdir(parents=True, exist_ok=True)
 
     meta_path = chunk_dir / "meta.json"
-    expected_meta = {
-        "version": 2,
-        "total_pairs": total,
-        "chunks_per_shard": int(chunks_per_shard),
-        "effective_chunks": len(chunk_ranges),
-    }
+    expected_meta = _stage6_expected_meta(total, chunks_per_shard)
     if meta_path.exists():
         with open(meta_path) as f:
             existing_meta = json.load(f)
@@ -3608,7 +3854,7 @@ def _compute_paper_geometry_row(paper):
     }
 
 
-def write_geometry_artifact(hg_path, outdir):
+def write_geometry_artifact(hg_path, outdir, source_label="hypergraphs"):
     with open(hg_path, "r", encoding="utf-8") as f:
         papers = json.load(f)
 
@@ -3621,6 +3867,8 @@ def write_geometry_artifact(hg_path, outdir):
     mean_t = (sum(valid) / len(valid)) if valid else 0.0
     stats = {
         "papers": len(rows),
+        "source": source_label,
+        "source_path": str(hg_path),
         "with_claims": len(valid),
         "empty_claim_papers": len(rows) - len(valid),
         "mean_T_total": round(float(mean_t), 4),
@@ -3628,6 +3876,20 @@ def write_geometry_artifact(hg_path, outdir):
         "max_T_total": round(max(valid), 4) if valid else None,
     }
     return stats, out_path
+
+
+def _arxiv_geometry_source_path(outdir, fallback_hg_path):
+    """Prefer Stage 5d paper hypergraphs for arXiv claim geometry.
+
+    Stage 9a's arXiv `hypergraphs.json` is an expression/term/scope graph and
+    intentionally does not contain claim nodes. Stage 5d's
+    `paper-hypergraphs.json` is the claim-bearing graph, so geometry must use it
+    when present.
+    """
+    paper_hg_path = Path(outdir) / "paper-hypergraphs.json"
+    if paper_hg_path.is_file():
+        return paper_hg_path, "paper-hypergraphs"
+    return Path(fallback_hg_path), "hypergraphs"
 
 
 # ---------------------------------------------------------------------------
@@ -4481,8 +4743,15 @@ def print_dry_run(args):
         cmd_parts.append(f"  --llm-stage3-batch-size {args.llm_stage3_batch_size}")
     if args.llm_stage3_chunks_per_shard != 10:
         cmd_parts.append(f"  --llm-stage3-chunks-per-shard {args.llm_stage3_chunks_per_shard}")
+    if args.llm_stage3_max_new_tokens != 64:
+        cmd_parts.append(f"  --llm-stage3-max-new-tokens {args.llm_stage3_max_new_tokens}")
     if args.llm_stage5d_batch_size != 4:
         cmd_parts.append(f"  --llm-stage5d-batch-size {args.llm_stage5d_batch_size}")
+    if args.llm_stage5d_checkpoint_chunk_size != 1000:
+        cmd_parts.append(
+            "  --llm-stage5d-checkpoint-chunk-size "
+            f"{args.llm_stage5d_checkpoint_chunk_size}"
+        )
     if args.llm_stage6_batch_size != 64:
         cmd_parts.append(f"  --llm-stage6-batch-size {args.llm_stage6_batch_size}")
     if args.llm_stage6_chunks_per_shard != 10:
@@ -4672,9 +4941,14 @@ def main():
                         help="LLM batch size for Stage 3 pattern tagging")
     parser.add_argument("--llm-stage3-chunks-per-shard", type=int, default=10,
                         help="Stage 3 output chunks per shard for resumable runs (default: 10)")
+    parser.add_argument("--llm-stage3-max-new-tokens", type=int, default=64,
+                        help="Maximum generated tokens for each Stage 3 pattern-tagging JSON response (default: 64)")
     parser.add_argument("--llm-stage5d-batch-size", type=int, default=4,
                         help="LLM batch size for Stage 5d paper hypergraph "
                              "implicit-edge extraction (default: 4)")
+    parser.add_argument("--llm-stage5d-checkpoint-chunk-size", type=int, default=1000,
+                        help="Checkpoint chunk size for resumable Stage 5d paper "
+                             "hypergraph output (default: 1000 papers)")
     parser.add_argument("--llm-stage6-batch-size", type=int, default=64,
                         help="LLM batch size for Stage 6 reverse morphogenesis "
                              "(default: 64)")
@@ -4818,6 +5092,10 @@ def main():
     # Health gates
     parser.add_argument("--preflight", action="store_true",
                         help="Strict health gates: abort on warnings (use for pre-flight validation runs)")
+    parser.add_argument("--gate-stage3-parse-rate-min", type=float, default=0.98,
+                        help="Minimum acceptable Stage 3 arXiv pattern-tag parse rate before warning/fail in preflight (default: 0.98)")
+    parser.add_argument("--gate-stage9a-geometry-claim-rate-min", type=float, default=0.01,
+                        help="Minimum acceptable arXiv Stage 9a geometry claim-paper rate before warning/fail in preflight (default: 0.01)")
     parser.add_argument("--gate-stage6-parse-rate-min", type=float, default=0.80,
                         help="Minimum acceptable Stage 6 parse_rate before warning/fail in preflight (default: 0.80)")
     parser.add_argument("--stage6-backend", type=str, default="local-llm",
@@ -4931,14 +5209,22 @@ def main():
         parser.error("--llm-stage3-batch-size must be > 0")
     if args.llm_stage3_chunks_per_shard <= 0:
         parser.error("--llm-stage3-chunks-per-shard must be > 0")
+    if args.llm_stage3_max_new_tokens <= 0:
+        parser.error("--llm-stage3-max-new-tokens must be > 0")
     if args.llm_stage5d_batch_size <= 0:
         parser.error("--llm-stage5d-batch-size must be > 0")
+    if args.llm_stage5d_checkpoint_chunk_size <= 0:
+        parser.error("--llm-stage5d-checkpoint-chunk-size must be > 0")
     if args.llm_stage6_batch_size <= 0:
         parser.error("--llm-stage6-batch-size must be > 0")
     if args.llm_stage6_chunks_per_shard <= 0:
         parser.error("--llm-stage6-chunks-per-shard must be > 0")
     if args.llm_loader_workers < 0:
         parser.error("--llm-loader-workers must be >= 0")
+    if not (0.0 <= args.gate_stage3_parse_rate_min <= 1.0):
+        parser.error("--gate-stage3-parse-rate-min must be in [0,1]")
+    if not (0.0 <= args.gate_stage9a_geometry_claim_rate_min <= 1.0):
+        parser.error("--gate-stage9a-geometry-claim-rate-min must be in [0,1]")
     if args.llm_gpu_workers < 0:
         parser.error("--llm-gpu-workers must be >= 0")
     if args.graph_embed_batch_size <= 0:
@@ -5136,6 +5422,7 @@ def main():
         if extra:
             record.update(extra)
         stage_status[stage_key] = record
+        write_stage_status(outdir, stage_key, record)
 
     # Health gate: warn or abort depending on --preflight
     def health_gate(stage: str, condition: bool, message: str):
@@ -5340,6 +5627,7 @@ def main():
                 batch_size=max_batch,
                 total_loader_workers=args.llm_loader_workers,
                 max_input_chars=args.technique_ner_llm_max_chars,
+                stage3_max_new_tokens=args.llm_stage3_max_new_tokens,
             )
             atexit.register(_close_llm_gpu_pool)
         return llm_gpu_pool
@@ -5371,15 +5659,27 @@ def main():
         print(f"\n[Stage 3/{n_stages}] LLM pattern tagging ({args.llm_model}, "
               f"batch={args.llm_stage3_batch_size}, "
               f"chunks={args.llm_stage3_chunks_per_shard}, "
+              f"max_new_tokens={args.llm_stage3_max_new_tokens}, "
               f"loader_workers={args.llm_loader_workers})...")
-        llm_pool = _ensure_llm_gpu_pool()
-        if llm_pool is None:
-            pipe, tok = _ensure_llm_pipeline()
-        else:
+        entry_ids = [e["entity/id"] for e in entities]
+        if _stage3_chunks_available_for_resume(
+            outdir,
+            entry_ids,
+            args.llm_stage3_chunks_per_shard,
+            args.llm_stage3_max_new_tokens,
+        ):
+            print("       Stage 3 chunks complete; reusing without loading LLM")
+            llm_pool = None
             pipe = tok = None
+        else:
+            llm_pool = _ensure_llm_gpu_pool()
+            if llm_pool is None:
+                pipe, tok = _ensure_llm_pipeline()
+            else:
+                pipe = tok = None
         pattern_tags = run_stage3_pattern_tagging_chunked(
             pairs,
-            entry_ids=[e["entity/id"] for e in entities],
+            entry_ids=entry_ids,
             outdir=outdir,
             pipe=pipe,
             tokenizer=tok,
@@ -5387,18 +5687,37 @@ def main():
             chunks_per_shard=args.llm_stage3_chunks_per_shard,
             loader_workers=args.llm_loader_workers,
             llm_pool=llm_pool,
+            max_new_tokens=args.llm_stage3_max_new_tokens,
         )
         print(f"       Stage 3 done in {time.time()-t3:.0f}s")
 
         # Pattern frequency summary
         from collections import Counter
         freq = Counter()
+        stage3_status_counts = Counter(r.get("status", "failed") for r in pattern_tags)
+        stage3_ok = stage3_status_counts.get("ok", 0)
+        stage3_parse_rate = stage3_ok / len(pattern_tags) if pattern_tags else 0.0
         for pt in pattern_tags:
             freq.update(pt["patterns"])
+        print(f"       Pattern tags parsed: {stage3_ok}/{len(pattern_tags)} "
+              f"({stage3_parse_rate:.1%})")
         print(f"       Pattern frequency (top 10):")
         for name, count in freq.most_common(10):
             print(f"         {name}: {count}")
-        mark_stage("llm_pattern_tags", "completed", tagged=len(pattern_tags))
+        health_gate(
+            "Stage 3",
+            args.arxiv_jsonl and stage3_parse_rate < args.gate_stage3_parse_rate_min,
+            f"pattern-tag parse rate {stage3_parse_rate:.1%} < "
+            f"{args.gate_stage3_parse_rate_min:.0%} threshold",
+        )
+        mark_stage(
+            "llm_pattern_tags",
+            "completed",
+            tagged=len(pattern_tags),
+            parsed_ok=int(stage3_ok),
+            parse_rate=round(float(stage3_parse_rate), 4),
+            status_counts=dict(stage3_status_counts),
+        )
     else:
         print(f"\n[Stage 3/{n_stages}] Skipped (--skip-llm)")
         mark_stage("llm_pattern_tags", "skipped", skip_reason="--skip-llm")
@@ -5536,14 +5855,80 @@ def main():
 
     def _previous_stage_status(stage_key):
         nonlocal previous_manifest
+        sidecar = read_stage_status(outdir, stage_key)
+        if isinstance(sidecar, dict):
+            return sidecar
         if previous_manifest is None:
-            manifest_path = outdir / "manifest.json"
-            try:
-                with open(manifest_path, encoding="utf-8") as f:
-                    previous_manifest = json.load(f)
-            except (OSError, json.JSONDecodeError):
-                previous_manifest = {}
+            previous_manifest = read_json_if_exists(outdir / "manifest.json") or {}
         return (previous_manifest.get("stage_status", {}) or {}).get(stage_key, {}) or {}
+
+    def _resume_recompute_error(stage_name, artifact_path, reason):
+        raise RuntimeError(
+            f"{stage_name} cannot safely resume existing {artifact_path.name}: "
+            f"{reason}. Move {artifact_path} aside and rerun so the stage "
+            "recomputes with fresh provenance."
+        )
+
+    def _validate_resumable_json_array(
+        stage_name,
+        stage_key,
+        artifact_path,
+        expected_ids,
+        *,
+        id_field,
+    ):
+        payload = read_json_if_exists(artifact_path)
+        if payload is None:
+            _resume_recompute_error(
+                stage_name,
+                artifact_path,
+                "artifact is unreadable or not valid JSON",
+            )
+        if not isinstance(payload, list):
+            _resume_recompute_error(
+                stage_name,
+                artifact_path,
+                f"expected JSON array but found {type(payload).__name__}",
+            )
+        if len(payload) != len(expected_ids):
+            _resume_recompute_error(
+                stage_name,
+                artifact_path,
+                f"row count {len(payload)} does not match entity count {len(expected_ids)}",
+            )
+        actual_ids = []
+        for idx, row in enumerate(payload):
+            if not isinstance(row, dict):
+                _resume_recompute_error(
+                    stage_name,
+                    artifact_path,
+                    f"row {idx} is {type(row).__name__}, expected object",
+                )
+            actual_id = row.get(id_field)
+            if not actual_id:
+                _resume_recompute_error(
+                    stage_name,
+                    artifact_path,
+                    f"row {idx} is missing required id field {id_field!r}",
+                )
+            actual_ids.append(actual_id)
+        if actual_ids != expected_ids:
+            _resume_recompute_error(
+                stage_name,
+                artifact_path,
+                f"{id_field} values do not align with current entities",
+            )
+
+        prior_status = _previous_stage_status(stage_key)
+        if paper_eprint_path is not None:
+            counts = prior_status.get("text_source_counts")
+            if not isinstance(counts, dict) or "eprint" not in counts:
+                _resume_recompute_error(
+                    stage_name,
+                    artifact_path,
+                    "stage-status provenance is missing text_source_counts for --paper-eprint-dir",
+                )
+        return prior_status
 
     def _require_paper_eprint_usage(stage_name, counts, produced):
         if paper_eprint_path is None or not produced:
@@ -5555,6 +5940,13 @@ def main():
             f"{paper_eprint_path}, but loaded zero eprints; refusing to "
             "write abstract-only paper-stage output"
         )
+
+    def _resumed_stage_extras(prior_status):
+        return {
+            key: value
+            for key, value in prior_status.items()
+            if key not in {"status", "resumed"}
+        }
 
     def _paper_text_for(entity, pair):
         """Return (text, source, eprint_meta) for a paper stage.
@@ -5588,14 +5980,23 @@ def main():
         techniques_path = outdir / "techniques.json"
         if techniques_path.exists():
             print(f"       Reusing existing {techniques_path.name}")
-            prev_counts = _previous_stage_status("technique_ner").get(
-                "text_source_counts", {}
+            prev_status = _validate_resumable_json_array(
+                "Stage 5c",
+                "technique_ner",
+                techniques_path,
+                [entity["entity/id"] for entity in entities],
+                id_field="paper_id",
             )
+            prev_counts = prev_status.get("text_source_counts", {})
             _require_paper_eprint_usage(
                 "Stage 5c", prev_counts, produced=True
             )
-            mark_stage("technique_ner", "completed", resumed=True,
-                       text_source_counts=prev_counts)
+            mark_stage(
+                "technique_ner",
+                "completed",
+                resumed=True,
+                **_resumed_stage_extras(prev_status),
+            )
         else:
             arm = args.technique_ner_arm
             concept_vocab: set[str] = set()
@@ -5729,6 +6130,18 @@ def main():
                 "Stage 5c", text_source_counts, produced=bool(records)
             )
 
+            stage5c_record = {
+                "n_papers": n_papers,
+                "arm": arm,
+                "arm_counts": arm_counts,
+                "text_source_counts": text_source_counts,
+                "eprint_status_counts": eprint_status_counts,
+            }
+            write_stage_status(
+                outdir,
+                "technique_ner",
+                {"status": "completed", **stage5c_record},
+            )
             with open(techniques_path, "w") as f:
                 json.dump(records, f, ensure_ascii=False, indent=2)
             print(f"       Saved {techniques_path.name} "
@@ -5741,10 +6154,7 @@ def main():
             if paper_eprint_path is not None:
                 print(f"       Eprint load status: {eprint_status_counts}")
             print(f"       Stage 5c done in {time.time()-t5c:.0f}s")
-            mark_stage("technique_ner", "completed",
-                       n_papers=n_papers, arm=arm, arm_counts=arm_counts,
-                       text_source_counts=text_source_counts,
-                       eprint_status_counts=eprint_status_counts)
+            mark_stage("technique_ner", "completed", **stage5c_record)
     else:
         print(f"\n[Stage 5c/{n_stages}] Skipped (--skip-technique-ner)")
         mark_stage("technique_ner", "skipped", skip_reason="--skip-technique-ner")
@@ -5759,20 +6169,99 @@ def main():
         print(f"\n[Stage 5d/{n_stages}] Paper hypergraph "
               f"(arm={args.paper_hypergraph_arm}, "
               f"llm_batch={args.llm_stage5d_batch_size}, "
+              f"checkpoint_chunk={args.llm_stage5d_checkpoint_chunk_size}, "
               f"loader_workers={args.llm_loader_workers})...")
         hg_path = outdir / "paper-hypergraphs.json"
         if hg_path.exists():
             print(f"       Reusing existing {hg_path.name}")
-            prev_counts = _previous_stage_status("paper_hypergraph").get(
-                "text_source_counts", {}
+            prev_status = _validate_resumable_json_array(
+                "Stage 5d",
+                "paper_hypergraph",
+                hg_path,
+                [entity["entity/id"] for entity in entities],
+                id_field="paper_id",
             )
+            prev_counts = prev_status.get("text_source_counts", {})
             _require_paper_eprint_usage(
                 "Stage 5d", prev_counts, produced=True
             )
-            mark_stage("paper_hypergraph", "completed", resumed=True,
-                       text_source_counts=prev_counts)
+            mark_stage(
+                "paper_hypergraph",
+                "completed",
+                resumed=True,
+                **_resumed_stage_extras(prev_status),
+            )
         else:
             arm = args.paper_hypergraph_arm
+            n_papers = len(pairs)
+            checkpoint_chunk_size = max(1, args.llm_stage5d_checkpoint_chunk_size)
+            chunk_ranges = _fixed_chunk_ranges(n_papers, checkpoint_chunk_size)
+            chunk_dir = outdir / "stage5d-paper-hypergraph-chunks"
+            chunk_dir.mkdir(parents=True, exist_ok=True)
+
+            meta_path = chunk_dir / "meta.json"
+            expected_meta = {
+                "version": 1,
+                "total_papers": n_papers,
+                "checkpoint_chunk_size": int(checkpoint_chunk_size),
+                "effective_chunks": len(chunk_ranges),
+                "arm": arm,
+                "llm_batch_size": int(args.llm_stage5d_batch_size),
+                "prose_cap_chars": int(args.paper_hypergraph_prose_cap),
+                "hg_cap_nodes": int(args.paper_hypergraph_node_cap),
+                "legacy_tex_normalization": True,
+            }
+            if meta_path.exists():
+                with open(meta_path) as f:
+                    existing_meta = json.load(f)
+                compatibility_keys = {
+                    "version",
+                    "total_papers",
+                    "arm",
+                    "llm_batch_size",
+                    "prose_cap_chars",
+                    "hg_cap_nodes",
+                    "legacy_tex_normalization",
+                }
+                if any(existing_meta.get(key) != expected_meta.get(key) for key in compatibility_keys):
+                    raise RuntimeError(
+                        f"Stage 5d chunk metadata mismatch in {meta_path}. "
+                        "Remove stage5d-paper-hypergraph-chunks to restart Stage 5d "
+                        "chunking with new parameters."
+                    )
+                existing_chunk_size = int(existing_meta.get("checkpoint_chunk_size", 0))
+                if existing_chunk_size <= 0:
+                    raise RuntimeError(
+                        f"Stage 5d chunk metadata in {meta_path} is missing a valid "
+                        "checkpoint_chunk_size."
+                    )
+                if existing_chunk_size != checkpoint_chunk_size:
+                    print(
+                        "       Reusing existing Stage 5d checkpoint geometry "
+                        f"({existing_chunk_size} papers/chunk) from {meta_path.name}"
+                    )
+                    checkpoint_chunk_size = existing_chunk_size
+                    chunk_ranges = _fixed_chunk_ranges(n_papers, checkpoint_chunk_size)
+                expected_meta = {
+                    "version": 1,
+                    "total_papers": n_papers,
+                    "checkpoint_chunk_size": int(checkpoint_chunk_size),
+                    "effective_chunks": len(chunk_ranges),
+                    "arm": arm,
+                    "llm_batch_size": int(args.llm_stage5d_batch_size),
+                    "prose_cap_chars": int(args.paper_hypergraph_prose_cap),
+                    "hg_cap_nodes": int(args.paper_hypergraph_node_cap),
+                    "legacy_tex_normalization": True,
+                }
+                if existing_meta != expected_meta:
+                    raise RuntimeError(
+                        f"Stage 5d chunk metadata mismatch in {meta_path}. "
+                        "Remove stage5d-paper-hypergraph-chunks to restart Stage 5d "
+                        "chunking with new parameters."
+                    )
+            else:
+                with open(meta_path, "w") as f:
+                    json.dump(expected_meta, f, ensure_ascii=False, indent=2)
 
             # Concept vocabulary from Stage 5
             concept_by_entity: dict[str, list[str]] = {}
@@ -5828,8 +6317,149 @@ def main():
                 else:
                     print("       Stage 5d using shared LLM GPU worker pool")
 
-            hypergraphs = [None] * len(pairs)
-            n_papers = len(pairs)
+            completed_chunks = 0
+            completed_papers = 0
+            hypergraphs = []
+            if chunk_ranges:
+                print(f"       Stage 5d chunking: {len(chunk_ranges)} chunks "
+                      f"(checkpoint_chunk_size={checkpoint_chunk_size})")
+
+                pending_chunks = []
+                for chunk_idx, start, end in chunk_ranges:
+                    chunk_size = end - start
+                    chunk_path = chunk_dir / f"chunk-{chunk_idx:03d}.json"
+                    if chunk_path.exists():
+                        completed_chunks += 1
+                        completed_papers += chunk_size
+                        print(f"       chunk {chunk_idx+1}/{len(chunk_ranges)} exists "
+                              f"({chunk_size} papers), skipping")
+                        continue
+                    pending_chunks.append((chunk_idx, start, end, chunk_path))
+
+                remaining_papers = n_papers - completed_papers
+                if remaining_papers > 0:
+                    print(f"       Stage 5d remaining this run: "
+                          f"{remaining_papers}/{n_papers} papers")
+
+                t_batch = time.time()
+                processed_this_run = 0
+                for chunk_idx, start, end, chunk_path in pending_chunks:
+                    chunk_size = end - start
+                    print(f"       chunk {chunk_idx+1}/{len(chunk_ranges)}: "
+                          f"papers[{start}:{end}] ({chunk_size})")
+                    chunk_texts = []
+                    chunk_classical_hgs = []
+                    chunk_results = []
+                    for i in range(start, end):
+                        entity = entities[i]
+                        pair = pairs[i]
+                        eid = entity["entity/id"]
+                        paper_text, text_source, _eprint_meta = _paper_text_for(entity, pair)
+                        concepts_p = concept_by_entity.get(eid, [])
+                        techniques_p = technique_by_entity.get(eid, [])
+                        normalization = None
+                        paper_text_stage5d = paper_text
+                        block_annotations = None
+                        if text_source == "eprint":
+                            normalization = normalize_legacy_tex(paper_text, paper_id=eid)
+                            paper_text_stage5d = normalization.rewritten_text
+                            block_annotations = normalization.block_annotations
+                        classical_hg = (
+                            extract_paper_hypergraph_classical(
+                                paper_text_stage5d, eid,
+                                concepts=concepts_p,
+                                techniques=techniques_p,
+                                block_annotations=block_annotations,
+                            )
+                            if arm in ("classical", "both")
+                            else {"paper_id": eid, "nodes": [], "edges": [],
+                                  "sectional": [], "meta": {}}
+                        )
+                        if normalization is not None and normalization.rewrites:
+                            classical_hg.setdefault("meta", {})["normalization"] = {
+                                "rewrites": len(normalization.rewrites),
+                                "aliases": dict(normalization.alias_map),
+                            }
+                        if arm in ("llm", "both"):
+                            chunk_texts.append(paper_text_stage5d)
+                            chunk_classical_hgs.append(classical_hg)
+                        else:
+                            chunk_results.append(classical_hg)
+
+                    if arm in ("llm", "both"):
+                        if stage5d_llm_pool is not None:
+                            llm_batches = stage5d_llm_pool.run_stage5d(
+                                chunk_texts,
+                                chunk_classical_hgs,
+                                prose_cap_chars=args.paper_hypergraph_prose_cap,
+                                hg_cap_nodes=args.paper_hypergraph_node_cap,
+                                batch_size=args.llm_stage5d_batch_size,
+                            )
+                        else:
+                            llm_batches = extract_paper_hypergraph_llm_batch(
+                                chunk_texts,
+                                chunk_classical_hgs,
+                                pipe=pipe_5d,
+                                tokenizer=tok_5d,
+                                prose_cap_chars=args.paper_hypergraph_prose_cap,
+                                hg_cap_nodes=args.paper_hypergraph_node_cap,
+                                batch_size=args.llm_stage5d_batch_size,
+                                loader_workers=args.llm_loader_workers,
+                            )
+                        for classical_hg, llm_edges in zip(chunk_classical_hgs, llm_batches):
+                            chunk_results.append(
+                                merge_paper_hypergraphs(classical_hg, llm_edges)
+                            )
+
+                    write_json(chunk_path, chunk_results, verbose=False)
+                    processed_this_run += chunk_size
+                    elapsed = time.time() - t_batch
+                    rate = processed_this_run / elapsed if elapsed > 0 else 0
+                    eta = max(remaining_papers - processed_this_run, 0) / rate if rate > 0 else 0
+                    print(f"       [{processed_this_run}/{remaining_papers}] {rate:.1f} papers/s, "
+                          f"ETA {eta/60:.0f} min")
+                    print(f"       chunk {chunk_idx+1}/{len(chunk_ranges)} written: "
+                          f"{chunk_path.name}")
+
+                hypergraphs = []
+                for chunk_idx, start, end in chunk_ranges:
+                    chunk_path = chunk_dir / f"chunk-{chunk_idx:03d}.json"
+                    if not chunk_path.exists():
+                        raise RuntimeError(
+                            f"Missing Stage 5d chunk file: {chunk_path}. "
+                            "Re-run Stage 5d or remove chunks to restart."
+                        )
+                    with open(chunk_path) as f:
+                        chunk_data = json.load(f)
+                    if not isinstance(chunk_data, list):
+                        raise RuntimeError(
+                            f"Invalid Stage 5d chunk payload (not a list): {chunk_path}"
+                        )
+                    expected_chunk_size = end - start
+                    if len(chunk_data) != expected_chunk_size:
+                        raise RuntimeError(
+                            f"Stage 5d chunk length mismatch in {chunk_path}: "
+                            f"chunk={len(chunk_data)} expected={expected_chunk_size}"
+                        )
+                    for offset, final_hg in enumerate(chunk_data):
+                        if not isinstance(final_hg, dict):
+                            raise RuntimeError(
+                                f"Invalid Stage 5d chunk row (not a dict): {chunk_path}"
+                            )
+                        expected_paper_id = entities[start + offset]["entity/id"]
+                        if final_hg.get("paper_id") != expected_paper_id:
+                            raise RuntimeError(
+                                f"Stage 5d chunk paper_id mismatch in {chunk_path}: "
+                                f"expected={expected_paper_id} got={final_hg.get('paper_id')}"
+                            )
+                    hypergraphs.extend(chunk_data)
+
+                if len(hypergraphs) != n_papers:
+                    raise RuntimeError(
+                        f"Stage 5d merge length mismatch: merged={len(hypergraphs)} "
+                        f"expected={n_papers}"
+                    )
+
             edge_provenance = {"classical": 0, "llm": 0, "both": 0}
             paper_hg_metrics = {
                 "n_blocks_total": 0,
@@ -5837,65 +6467,25 @@ def main():
                 "normalized_papers": 0,
                 "normalization_rewrites": 0,
             }
-            text_source_counts = {"eprint": 0, "abstract": 0}
-            eprint_status_counts = {}
-            t_batch = time.time()
-            llm_chunk_size = max(1, args.llm_stage5d_batch_size * 8)
-            pending_texts = []
-            pending_hgs = []
-            pending_items = []
-
-            def _record_paper_hg(idx, final_hg):
+            for final_hg in hypergraphs:
                 for e in final_hg["edges"]:
                     prov = e.get("attrs", {}).get("provenance", "classical")
                     edge_provenance[prov] = edge_provenance.get(prov, 0) + 1
-
-                paper_hg_metrics["n_blocks_total"] += (
-                    final_hg.get("meta", {}).get("n_blocks", 0)
-                )
-                if final_hg.get("meta", {}).get("has_theorem_blocks"):
+                meta = final_hg.get("meta", {})
+                paper_hg_metrics["n_blocks_total"] += meta.get("n_blocks", 0)
+                if meta.get("has_theorem_blocks"):
                     paper_hg_metrics["n_with_claim_blocks"] += 1
-                hypergraphs[idx] = final_hg
-
-            def _flush_paper_hg_llm(final_flush=False):
-                if not pending_items:
-                    return
-                if stage5d_llm_pool is not None:
-                    llm_batches = stage5d_llm_pool.run_stage5d(
-                        pending_texts,
-                        pending_hgs,
-                        prose_cap_chars=args.paper_hypergraph_prose_cap,
-                        hg_cap_nodes=args.paper_hypergraph_node_cap,
-                        batch_size=args.llm_stage5d_batch_size,
+                normalization_meta = meta.get("normalization")
+                if isinstance(normalization_meta, dict):
+                    paper_hg_metrics["normalized_papers"] += 1
+                    paper_hg_metrics["normalization_rewrites"] += int(
+                        normalization_meta.get("rewrites", 0) or 0
                     )
-                else:
-                    llm_batches = extract_paper_hypergraph_llm_batch(
-                        pending_texts,
-                        pending_hgs,
-                        pipe=pipe_5d,
-                        tokenizer=tok_5d,
-                        prose_cap_chars=args.paper_hypergraph_prose_cap,
-                        hg_cap_nodes=args.paper_hypergraph_node_cap,
-                        batch_size=args.llm_stage5d_batch_size,
-                        loader_workers=args.llm_loader_workers,
-                    )
-                for (idx, classical_hg), llm_edges in zip(pending_items, llm_batches):
-                    final_hg = merge_paper_hypergraphs(classical_hg, llm_edges)
-                    _record_paper_hg(idx, final_hg)
-                pending_items.clear()
-                pending_texts.clear()
-                pending_hgs.clear()
-                done = sum(1 for h in hypergraphs if h is not None)
-                elapsed = time.time() - t_batch
-                rate = done / elapsed if elapsed > 0 else 0
-                eta = (n_papers - done) / rate if rate > 0 else 0
-                if done % 100 == 0 or done == n_papers or final_flush:
-                    print(f"       [{done}/{n_papers}] {rate:.1f} papers/s, "
-                          f"ETA {eta/60:.0f} min")
 
-            for i, (entity, pair) in enumerate(zip(entities, pairs)):
-                eid = entity["entity/id"]
-                paper_text, text_source, eprint_meta = _paper_text_for(entity, pair)
+            text_source_counts = {"eprint": 0, "abstract": 0}
+            eprint_status_counts = {}
+            for entity, pair in zip(entities, pairs):
+                _paper_text, text_source, eprint_meta = _paper_text_for(entity, pair)
                 text_source_counts[text_source] = (
                     text_source_counts.get(text_source, 0) + 1
                 )
@@ -5903,70 +6493,38 @@ def main():
                 eprint_status_counts[eprint_status] = (
                     eprint_status_counts.get(eprint_status, 0) + 1
                 )
-                concepts_p = concept_by_entity.get(eid, [])
-                techniques_p = technique_by_entity.get(eid, [])
-                normalization = None
-                paper_text_stage5d = paper_text
-                block_annotations = None
-                if text_source == "eprint":
-                    normalization = normalize_legacy_tex(paper_text, paper_id=eid)
-                    paper_text_stage5d = normalization.rewritten_text
-                    block_annotations = normalization.block_annotations
-                    if normalization.rewrites:
-                        paper_hg_metrics["normalized_papers"] += 1
-                        paper_hg_metrics["normalization_rewrites"] += len(normalization.rewrites)
-
-                classical_hg = (
-                    extract_paper_hypergraph_classical(
-                        paper_text_stage5d, eid,
-                        concepts=concepts_p,
-                        techniques=techniques_p,
-                        block_annotations=block_annotations,
-                    )
-                    if arm in ("classical", "both")
-                    else {"paper_id": eid, "nodes": [], "edges": [],
-                          "sectional": [], "meta": {}}
-                )
-                if normalization is not None and normalization.rewrites:
-                    classical_hg.setdefault("meta", {})["normalization"] = {
-                        "rewrites": len(normalization.rewrites),
-                        "aliases": dict(normalization.alias_map),
-                    }
-
-                if arm in ("llm", "both"):
-                    pending_texts.append(paper_text_stage5d)
-                    pending_hgs.append(classical_hg)
-                    pending_items.append((i, classical_hg))
-                    if len(pending_items) >= llm_chunk_size:
-                        _flush_paper_hg_llm()
-                    continue
-                else:
-                    final_hg = classical_hg
-
-                _record_paper_hg(i, final_hg)
-
-                if (i + 1) % 100 == 0 or (i + 1) == n_papers:
-                    elapsed = time.time() - t_batch
-                    done = i + 1
-                    rate = done / elapsed if elapsed > 0 else 0
-                    eta = (n_papers - done) / rate if rate > 0 else 0
-                    print(f"       [{done}/{n_papers}] {rate:.1f} papers/s, "
-                          f"ETA {eta/60:.0f} min")
-
-            _flush_paper_hg_llm(final_flush=True)
-            if any(h is None for h in hypergraphs):
-                missing = sum(1 for h in hypergraphs if h is None)
-                raise RuntimeError(f"Stage 5d did not produce {missing} hypergraphs")
             _require_paper_eprint_usage(
                 "Stage 5d", text_source_counts, produced=bool(hypergraphs)
             )
 
+            stage5d_record = {
+                "n_papers": n_papers,
+                "arm": arm,
+                "llm_batch_size": args.llm_stage5d_batch_size,
+                "total_nodes": sum(len(h["nodes"]) for h in hypergraphs),
+                "total_edges": sum(len(h["edges"]) for h in hypergraphs),
+                "with_claim_blocks": paper_hg_metrics["n_with_claim_blocks"],
+                "edge_provenance": edge_provenance,
+                "text_source_counts": text_source_counts,
+                "eprint_status_counts": eprint_status_counts,
+                "normalized_papers": paper_hg_metrics["normalized_papers"],
+                "normalization_rewrites": paper_hg_metrics["normalization_rewrites"],
+                "chunk_count": len(chunk_ranges),
+                "resumed_chunks": completed_chunks,
+                "resumed_papers": completed_papers,
+                "resumed_from_chunks": completed_chunks > 0,
+            }
+            write_stage_status(
+                outdir,
+                "paper_hypergraph",
+                {"status": "completed", **stage5d_record},
+            )
             with open(hg_path, "w") as f:
                 json.dump(hypergraphs, f, ensure_ascii=False)
-            total_edges = sum(len(h["edges"]) for h in hypergraphs)
-            total_nodes = sum(len(h["nodes"]) for h in hypergraphs)
+            total_edges = stage5d_record["total_edges"]
+            total_nodes = stage5d_record["total_nodes"]
             n_blocks_total = paper_hg_metrics["n_blocks_total"]
-            n_with_claim_blocks = paper_hg_metrics["n_with_claim_blocks"]
+            n_with_claim_blocks = stage5d_record["with_claim_blocks"]
             print(f"       Saved {hg_path.name}: {total_nodes} nodes, "
                   f"{total_edges} edges across {n_papers} papers")
             print(f"       Papers with theorem/lemma/proposition blocks: "
@@ -5985,16 +6543,7 @@ def main():
             if paper_eprint_path is not None:
                 print(f"       Eprint load status: {eprint_status_counts}")
             print(f"       Stage 5d done in {time.time()-t5d:.0f}s")
-            mark_stage("paper_hypergraph", "completed",
-                       n_papers=n_papers, arm=arm,
-                       llm_batch_size=args.llm_stage5d_batch_size,
-                       total_nodes=total_nodes, total_edges=total_edges,
-                       with_claim_blocks=n_with_claim_blocks,
-                       normalized_papers=paper_hg_metrics["normalized_papers"],
-                       normalization_rewrites=paper_hg_metrics["normalization_rewrites"],
-                       edge_provenance=edge_provenance,
-                       text_source_counts=text_source_counts,
-                       eprint_status_counts=eprint_status_counts)
+            mark_stage("paper_hypergraph", "completed", **stage5d_record)
     else:
         print(f"\n[Stage 5d/{n_stages}] Skipped (--skip-paper-hypergraph)")
         mark_stage("paper_hypergraph", "skipped", skip_reason="--skip-paper-hypergraph")
@@ -6023,12 +6572,21 @@ def main():
               f"batch={args.llm_stage6_batch_size}, "
               f"chunks={args.llm_stage6_chunks_per_shard}, "
               f"loader_workers={args.llm_loader_workers})...")
-        llm_pool = _ensure_llm_gpu_pool()
-        if llm_pool is None:
-            pipe, tok = _ensure_llm_pipeline()
-        else:
-            print("       Stage 6 using shared LLM GPU worker pool")
+        if _stage6_chunks_available_for_resume(
+            outdir,
+            len(pairs),
+            args.llm_stage6_chunks_per_shard,
+        ):
+            print("       Stage 6 chunks complete; reusing without loading LLM")
+            llm_pool = None
             pipe = tok = None
+        else:
+            llm_pool = _ensure_llm_gpu_pool()
+            if llm_pool is None:
+                pipe, tok = _ensure_llm_pipeline()
+            else:
+                print("       Stage 6 using shared LLM GPU worker pool")
+                pipe = tok = None
         rm_results = run_stage6_reverse_morphogenesis_chunked(
             pairs,
             entities,
@@ -6328,12 +6886,20 @@ def main():
             print(f"       Eprint text coverage: {stage9a_stats.get('eprint_text_used', 0)}/"
                   f"{stage9a_stats.get('papers_processed', 0)} "
                   f"(missing={stage9a_stats.get('eprint_text_missing', 0)})")
-        geometry_stats, geometry_path = write_geometry_artifact(hg_path, outdir)
+        geometry_source_path, geometry_source = _arxiv_geometry_source_path(outdir, hg_path)
+        geometry_stats, geometry_path = write_geometry_artifact(
+            geometry_source_path,
+            outdir,
+            source_label=geometry_source,
+        )
         stage9a_stats["geometry_stats"] = geometry_stats
         stage9a_stats["geometry_path"] = str(geometry_path)
+        stage9a_stats["geometry_source"] = geometry_source
+        stage9a_stats["geometry_source_path"] = str(geometry_source_path)
         print(f"       Geometry artifact: {geometry_path.name} "
               f"(with_claims={geometry_stats['with_claims']}/"
-              f"{geometry_stats['papers']}, std={geometry_stats['std_T_total']:.3f})")
+              f"{geometry_stats['papers']}, source={geometry_source}, "
+              f"std={geometry_stats['std_T_total']:.3f})")
         print(f"       Written {hg_path} "
               f"({os.path.getsize(hg_path) / 1e6:.1f} MB)")
         print(f"       Stage 9a done in {time.time()-t9:.0f}s")
@@ -6341,15 +6907,34 @@ def main():
         assembly_rate = (stage9a_stats['hypergraphs_produced']
                          / stage9a_stats.get('papers_processed', 0)
                          if stage9a_stats.get('papers_processed', 0) else 0)
+        geometry_claim_rate = (
+            geometry_stats["with_claims"] / geometry_stats["papers"]
+            if geometry_stats["papers"] else 0.0
+        )
         health_gate("Stage 9a", assembly_rate < 0.90,
                     f"assembly rate {assembly_rate:.1%} < 90% — hypergraph schema too rigid")
         health_gate("Stage 9a", stage9a_stats['avg_nodes'] < 3,
                     f"avg {stage9a_stats['avg_nodes']:.1f} nodes/paper — hypergraphs are trivial")
+        health_gate(
+            "Stage 9a",
+            geometry_source == "hypergraphs",
+            "arXiv geometry fell back to claim-free Stage 9a hypergraphs; "
+            "paper-hypergraphs.json is missing",
+        )
+        health_gate(
+            "Stage 9a",
+            geometry_claim_rate < args.gate_stage9a_geometry_claim_rate_min,
+            f"geometry claim-paper rate {geometry_claim_rate:.1%} < "
+            f"{args.gate_stage9a_geometry_claim_rate_min:.0%} threshold",
+        )
         mark_stage(
             "hypergraphs",
             "completed",
             produced=int(stage9a_stats["hypergraphs_produced"]),
             processed=int(stage9a_stats.get("papers_processed", 0)),
+            geometry_with_claims=int(geometry_stats["with_claims"]),
+            geometry_claim_rate=round(float(geometry_claim_rate), 4),
+            geometry_source=geometry_source,
         )
     elif (not args.skip_hypergraphs and not args.skip_threads
             and threads and (ct_wiring_path or thread_diagrams)):
@@ -6528,6 +7113,11 @@ def main():
     # ========== Manifest ==========
     elapsed = time.time() - t0
     readiness_status = "pass" if not health_issues else "warn"
+    persisted_stage_status = {}
+    for status_file in sorted(stage_status_dir(outdir).glob("*.json")):
+        payload = read_json_if_exists(status_file)
+        if isinstance(payload, dict):
+            persisted_stage_status[status_file.stem] = payload
     manifest = {
         "generated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         "run": {
@@ -6548,6 +7138,9 @@ def main():
             "stage3": args.llm_stage3_batch_size,
             "stage5d": args.llm_stage5d_batch_size,
             "stage6": args.llm_stage6_batch_size,
+        },
+        "llm_generation_max_new_tokens": {
+            "stage3": args.llm_stage3_max_new_tokens,
         },
         "stats": stats,
         "entity_count": len(entities),
@@ -6573,9 +7166,11 @@ def main():
         },
         "stage6_backend": args.stage6_backend,
         "health_gate_thresholds": {
+            "stage3_parse_rate_min": args.gate_stage3_parse_rate_min,
             "stage6_parse_rate_min": args.gate_stage6_parse_rate_min,
             "stage7_categorical_rate_min": args.gate_stage7_categorical_rate_min,
             "stage7_port_rate_min": args.gate_stage7_port_rate_min,
+            "stage9a_geometry_claim_rate_min": args.gate_stage9a_geometry_claim_rate_min,
             "stage9b_val_acc1_min": args.gate_stage9b_val_acc1_min,
         },
         "readiness": {
@@ -6606,7 +7201,7 @@ def main():
         "stage9a_stats": stage9a_stats,
         "stage9b_stats": stage9b_stats,
         "stage10_stats": stage10_stats,
-        "stage_status": stage_status,
+        "stage_status": {**persisted_stage_status, **stage_status},
         "health_issues": health_issues,
         "output_files": [f.name for f in outdir.iterdir() if f.is_file()],
         "patterns": (None if args.arxiv_jsonl else PATTERN_NAMES),

--- a/src/futon6/arxiv_pattern_prompt.py
+++ b/src/futon6/arxiv_pattern_prompt.py
@@ -60,7 +60,7 @@ def _default_futon3_library() -> Path:
     candidates.append(DEFAULT_FUTON3_LIBRARY)
 
     # The superpod installation keeps futons as sibling checkouts under darktower.
-    darktower_library = Path(__file__).resolve().parents[3] / "futon3" / "library"
+    darktower_library = Path(__file__).resolve().parents[2] / "futon3" / "library"
     candidates.append(darktower_library)
 
     for candidate in candidates:

--- a/src/futon6/arxiv_pattern_prompt.py
+++ b/src/futon6/arxiv_pattern_prompt.py
@@ -20,6 +20,7 @@ deploys the Stage 3 fork.
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -44,6 +45,28 @@ FAMILY_PARENTS = [
     "math-strategy/property-of-object-result",
     "math-strategy/clarification-meta",
 ]
+
+
+def _has_paper_shape_families(library_root: Path) -> bool:
+    return all((library_root / f"{parent_id}.flexiarg").is_file() for parent_id in FAMILY_PARENTS)
+
+
+def _default_futon3_library() -> Path:
+    candidates: list[Path] = []
+    if env_library := os.environ.get("FUTON3_LIBRARY"):
+        candidates.append(Path(env_library).expanduser())
+    if env_root := os.environ.get("FUTON3_ROOT"):
+        candidates.append(Path(env_root).expanduser() / "library")
+    candidates.append(DEFAULT_FUTON3_LIBRARY)
+
+    # The superpod installation keeps futons as sibling checkouts under darktower.
+    darktower_library = Path(__file__).resolve().parents[3] / "futon3" / "library"
+    candidates.append(darktower_library)
+
+    for candidate in candidates:
+        if _has_paper_shape_families(candidate):
+            return candidate
+    return candidates[0]
 
 
 @dataclass
@@ -118,7 +141,7 @@ def _parse_one_flexiarg(path: Path) -> Optional[Pattern]:
     )
 
 
-def load_paper_shape_taxonomy(library_root: Path = DEFAULT_FUTON3_LIBRARY) -> PaperShapeTaxonomy:
+def load_paper_shape_taxonomy(library_root: Optional[Path] = None) -> PaperShapeTaxonomy:
     """Load the 5-family + leaves paper-shape taxonomy from futon3 flexiargs.
 
     Family parents declare member-pattern lists; leaves declare @family.
@@ -126,6 +149,8 @@ def load_paper_shape_taxonomy(library_root: Path = DEFAULT_FUTON3_LIBRARY) -> Pa
     leaf's @family is missing (e.g. existing patterns that pre-date the
     taxonomy and haven't been retrofitted with @family).
     """
+    if library_root is None:
+        library_root = _default_futon3_library()
     families: dict[str, Pattern] = {}
     for parent_id in FAMILY_PARENTS:
         rel = parent_id + ".flexiarg"
@@ -251,6 +276,37 @@ JSON output:"""
 
 
 _VALID_FAMILY_IDS = set(FAMILY_PARENTS)
+_INVALID_JSON_ESCAPE_RE = re.compile(r"\\(?![\"\\/bfnrtu])")
+
+
+def _json_loads_tolerating_tex_escapes(blob: str) -> tuple[dict | None, str | None]:
+    """Parse LLM JSON, retrying after escaping raw TeX backslashes.
+
+    Llama often writes rationale strings containing TeX such as ``\\mathbb``.
+    That is semantically valid text but invalid JSON because ``\\m`` is not an
+    allowed JSON escape. Doubling only invalid backslashes preserves ordinary
+    JSON escapes while recovering these otherwise-useful Stage 3 records.
+    """
+    try:
+        obj = json.loads(blob)
+        return (obj if isinstance(obj, dict) else None), None
+    except json.JSONDecodeError as first_exc:
+        repaired = _INVALID_JSON_ESCAPE_RE.sub(r"\\\\", blob)
+        if repaired == blob:
+            return None, f"json-decode: {first_exc}"
+        try:
+            obj = json.loads(repaired)
+            return (obj if isinstance(obj, dict) else None), None
+        except json.JSONDecodeError as second_exc:
+            return None, f"json-decode: {second_exc}"
+
+
+def _coerce_confidence(value, *, default: float = 0.0) -> float:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(0.0, min(1.0, parsed))
 
 
 def parse_arxiv_pattern_response(
@@ -275,36 +331,52 @@ def parse_arxiv_pattern_response(
     if brace_start < 0 or brace_end < brace_start:
         return {"ok": False, "error": "no-json-object", "raw_excerpt": text[:200]}
     blob = text[brace_start:brace_end + 1]
-    try:
-        obj = json.loads(blob)
-    except json.JSONDecodeError as exc:
-        return {"ok": False, "error": f"json-decode: {exc}", "raw_excerpt": blob[:200]}
+    obj, json_error = _json_loads_tolerating_tex_escapes(blob)
+    if obj is None:
+        return {
+            "ok": False,
+            "error": json_error or "json-not-object",
+            "raw_excerpt": blob[:200],
+        }
 
     family = obj.get("family", "")
     leaf = obj.get("leaf", "")
     if family not in _VALID_FAMILY_IDS:
-        return {"ok": False, "error": f"invalid-family: {family!r}", "raw_excerpt": blob[:200]}
+        return {
+            "ok": False,
+            "error": f"invalid-family: {family!r}",
+            "raw_excerpt": blob[:200],
+        }
+    warnings: list[str] = []
     if leaf != "uncertain" and leaf not in taxonomy.leaves and leaf:
-        # Accept absence of leaf only when family is clarification-meta or
-        # leaf is missing entirely.
-        if family != "math-strategy/clarification-meta":
-            return {"ok": False,
-                    "error": f"invalid-leaf: {leaf!r} not in taxonomy",
-                    "raw_excerpt": blob[:200]}
+        if family == "math-strategy/clarification-meta":
+            leaf = ""
+        else:
+            warnings.append(f"invalid-leaf-normalized: {leaf!r}")
+            leaf = "uncertain"
+            obj["leaf_confidence"] = min(
+                _coerce_confidence(obj.get("leaf_confidence")),
+                0.5,
+            )
 
     if family == "math-strategy/clarification-meta":
         collapsed = obj.get("collapsed")
         if not isinstance(collapsed, dict) or "reason" not in collapsed:
-            return {"ok": False,
-                    "error": "clarification-meta requires `collapsed: {reason, explanation}`",
-                    "raw_excerpt": blob[:200]}
+            warnings.append("clarification-meta-collapsed-synthesized")
+            obj["collapsed"] = {
+                "reason": "other",
+                "explanation": str(
+                    obj.get("rationale", "") or "LLM omitted collapsed metadata."
+                ),
+            }
 
     return {
         "ok": True,
         "family": family,
         "leaf": leaf or None,
-        "family_confidence": float(obj.get("family_confidence", 0.0)),
-        "leaf_confidence": float(obj.get("leaf_confidence", 0.0)),
+        "family_confidence": _coerce_confidence(obj.get("family_confidence")),
+        "leaf_confidence": _coerce_confidence(obj.get("leaf_confidence")),
         "rationale": obj.get("rationale", ""),
         "collapsed": obj.get("collapsed"),
+        "warnings": warnings,
     }

--- a/src/futon6/graph_embed.py
+++ b/src/futon6/graph_embed.py
@@ -456,6 +456,26 @@ def contrastive_collate_fn(batch):
     return collate_graphs(view1), collate_graphs(view2)
 
 
+def _shutdown_dataloader_workers(loader: DataLoader | None, iterator=None) -> None:
+    """Best-effort shutdown for multiprocessing DataLoader workers."""
+    if loader is None:
+        return
+    target = iterator
+    if target is None:
+        target = getattr(loader, "_iterator", None)
+    shutdown = getattr(target, "_shutdown_workers", None)
+    if callable(shutdown):
+        try:
+            shutdown()
+        except Exception:
+            pass
+    if hasattr(loader, "_iterator"):
+        try:
+            loader._iterator = None
+        except Exception:
+            pass
+
+
 def _split_train_val_indices(
     n: int,
     val_frac: float = 0.1,
@@ -662,6 +682,7 @@ def train(hypergraphs: list[dict], dim: int = 128, hidden_dim: int = 128,
     use_dataloader = num_workers > 0 and n_train >= batch_size
     use_cuda = device != "cpu" and torch.cuda.is_available()
 
+    loader = None
     if use_dataloader:
         dataset = ContrastiveGraphDataset(train_graphs, node_drop, edge_drop)
         loader = DataLoader(
@@ -680,105 +701,109 @@ def train(hypergraphs: list[dict], dim: int = 128, hidden_dim: int = 128,
     val_curve = []
     best_val_acc1 = -1.0
     best_val_epoch = None
+    loader_iter = None
+    try:
+        for epoch in range(epochs):
+            model.train()
+            total_loss = 0.0
+            n_batches = 0
 
-    for epoch in range(epochs):
-        model.train()
-        total_loss = 0.0
-        n_batches = 0
+            if use_dataloader:
+                loader_iter = iter(loader)
+                for batch1, batch2 in loader_iter:
+                    batch1 = batch1.to(device)
+                    batch2 = batch2.to(device)
 
-        if use_dataloader:
-            for batch1, batch2 in loader:
-                batch1 = batch1.to(device)
-                batch2 = batch2.to(device)
+                    z1 = model(batch1)
+                    z2 = model(batch2)
 
-                z1 = model(batch1)
-                z2 = model(batch2)
+                    loss = info_nce_loss(z1, z2)
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
 
-                loss = info_nce_loss(z1, z2)
-                optimizer.zero_grad()
-                loss.backward()
-                optimizer.step()
+                    total_loss += loss.item()
+                    n_batches += 1
+            else:
+                # Fallback: manual batching (for small datasets or debugging)
+                indices = list(range(n_train))
+                random.shuffle(indices)
 
-                total_loss += loss.item()
-                n_batches += 1
-        else:
-            # Fallback: manual batching (for small datasets or debugging)
-            indices = list(range(n_train))
-            random.shuffle(indices)
+                for start in range(0, n_train, batch_size):
+                    batch_idx = indices[start:start + batch_size]
+                    if len(batch_idx) < 2:
+                        continue
 
-            for start in range(0, n_train, batch_size):
-                batch_idx = indices[start:start + batch_size]
-                if len(batch_idx) < 2:
-                    continue
+                    view1 = []
+                    view2 = []
+                    for idx in batch_idx:
+                        x, ei = train_graphs[idx]
+                        x1, ei1 = augment_graph(x, ei, node_drop, edge_drop)
+                        x2, ei2 = augment_graph(x, ei, node_drop, edge_drop)
+                        view1.append((x1, ei1))
+                        view2.append((x2, ei2))
 
-                view1 = []
-                view2 = []
-                for idx in batch_idx:
-                    x, ei = train_graphs[idx]
-                    x1, ei1 = augment_graph(x, ei, node_drop, edge_drop)
-                    x2, ei2 = augment_graph(x, ei, node_drop, edge_drop)
-                    view1.append((x1, ei1))
-                    view2.append((x2, ei2))
+                    b1 = collate_graphs(view1).to(device)
+                    b2 = collate_graphs(view2).to(device)
 
-                b1 = collate_graphs(view1).to(device)
-                b2 = collate_graphs(view2).to(device)
+                    z1 = model(b1)
+                    z2 = model(b2)
 
-                z1 = model(b1)
-                z2 = model(b2)
+                    loss = info_nce_loss(z1, z2)
+                    optimizer.zero_grad()
+                    loss.backward()
+                    optimizer.step()
 
-                loss = info_nce_loss(z1, z2)
-                optimizer.zero_grad()
-                loss.backward()
-                optimizer.step()
+                    total_loss += loss.item()
+                    n_batches += 1
 
-                total_loss += loss.item()
-                n_batches += 1
+            avg_loss = total_loss / max(1, n_batches)
+            loss_curve.append(float(avg_loss))
 
-        avg_loss = total_loss / max(1, n_batches)
-        loss_curve.append(float(avg_loss))
+            val_metrics = None
+            eval_now = ((epoch + 1) % eval_every == 0) or ((epoch + 1) == epochs)
+            if eval_now and val_idx:
+                model.eval()
+                val_metrics = _paired_retrieval_metrics(
+                    model=model,
+                    graph_tensors=all_graph_tensors,
+                    indices=val_idx,
+                    batch_size=batch_size,
+                    device=device,
+                    node_drop=node_drop,
+                    edge_drop=edge_drop,
+                )
+                val_metrics["epoch"] = int(epoch + 1)
+                val_curve.append(val_metrics)
+                if val_metrics["acc_at_1"] > best_val_acc1:
+                    best_val_acc1 = val_metrics["acc_at_1"]
+                    best_val_epoch = int(epoch + 1)
 
-        val_metrics = None
-        eval_now = ((epoch + 1) % eval_every == 0) or ((epoch + 1) == epochs)
-        if eval_now and val_idx:
-            model.eval()
-            val_metrics = _paired_retrieval_metrics(
-                model=model,
-                graph_tensors=all_graph_tensors,
-                indices=val_idx,
-                batch_size=batch_size,
-                device=device,
-                node_drop=node_drop,
-                edge_drop=edge_drop,
-            )
-            val_metrics["epoch"] = int(epoch + 1)
-            val_curve.append(val_metrics)
-            if val_metrics["acc_at_1"] > best_val_acc1:
-                best_val_acc1 = val_metrics["acc_at_1"]
-                best_val_epoch = int(epoch + 1)
+            log_now = ((epoch + 1) % max(1, epochs // 10) == 0) or ((epoch + 1) == epochs)
+            if verbose and log_now:
+                msg = f"       Epoch {epoch+1}/{epochs}  loss={avg_loss:.4f}"
+                if val_metrics is not None:
+                    msg += ("  val_acc@1={:.3f} val_acc@5={:.3f} val_mrr={:.3f} n={}".format(
+                        val_metrics["acc_at_1"],
+                        val_metrics["acc_at_5"],
+                        val_metrics["mrr"],
+                        val_metrics["n_eval"],
+                    ))
+                print(msg)
 
-        log_now = ((epoch + 1) % max(1, epochs // 10) == 0) or ((epoch + 1) == epochs)
-        if verbose and log_now:
-            msg = f"       Epoch {epoch+1}/{epochs}  loss={avg_loss:.4f}"
-            if val_metrics is not None:
-                msg += ("  val_acc@1={:.3f} val_acc@5={:.3f} val_mrr={:.3f} n={}".format(
-                    val_metrics["acc_at_1"],
-                    val_metrics["acc_at_5"],
-                    val_metrics["mrr"],
-                    val_metrics["n_eval"],
-                ))
-            print(msg)
+        # Final embedding pass
+        model.eval()
+        all_embeddings = []
+        with torch.no_grad():
+            for start in range(0, len(all_graph_tensors), batch_size):
+                batch_graphs = all_graph_tensors[start:start + batch_size]
+                batch = collate_graphs(batch_graphs).to(device)
+                emb = model.embed(batch)
+                all_embeddings.append(emb.cpu().numpy())
 
-    # Final embedding pass
-    model.eval()
-    all_embeddings = []
-    with torch.no_grad():
-        for start in range(0, len(all_graph_tensors), batch_size):
-            batch_graphs = all_graph_tensors[start:start + batch_size]
-            batch = collate_graphs(batch_graphs).to(device)
-            emb = model.embed(batch)
-            all_embeddings.append(emb.cpu().numpy())
-
-    embeddings = np.concatenate(all_embeddings, axis=0)
+        embeddings = np.concatenate(all_embeddings, axis=0)
+    finally:
+        _shutdown_dataloader_workers(loader, loader_iter)
 
     final_val = val_curve[-1] if val_curve else None
     loss_initial = float(loss_curve[0]) if loss_curve else None

--- a/tests/test_arxiv_pattern_prompt.py
+++ b/tests/test_arxiv_pattern_prompt.py
@@ -4,7 +4,7 @@ Validates:
 - Taxonomy loads from futon3/library/ flexiargs.
 - Prompt builder emits a coherent string with all 5 families and leaves.
 - Response parser accepts well-formed responses, rejects malformed ones,
-  and enforces clarification-meta's `:reason` requirement.
+  and repairs common local-LLM JSON/taxonomy drift without dropping records.
 """
 from __future__ import annotations
 
@@ -21,7 +21,21 @@ from futon6.arxiv_pattern_prompt import (
 )
 
 
-_LIBRARY_ROOT = Path.home() / "code" / "futon3" / "library"
+_LIBRARY_CANDIDATES = []
+if env_library := os.environ.get("FUTON3_LIBRARY"):
+    _LIBRARY_CANDIDATES.append(Path(env_library))
+if env_root := os.environ.get("FUTON3_ROOT"):
+    _LIBRARY_CANDIDATES.append(Path(env_root) / "library")
+_LIBRARY_CANDIDATES.extend(
+    [
+        Path.home() / "code" / "futon3" / "library",
+        Path(__file__).resolve().parents[2] / "futon3" / "library",
+    ]
+)
+_LIBRARY_ROOT = next(
+    (candidate for candidate in _LIBRARY_CANDIDATES if candidate.exists()),
+    _LIBRARY_CANDIDATES[0],
+)
 _HAS_LIBRARY = _LIBRARY_ROOT.exists()
 
 
@@ -136,7 +150,7 @@ class TestResponseParser(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["leaf"], "uncertain")
 
-    def test_clarification_meta_requires_collapsed(self):
+    def test_clarification_meta_without_collapsed_is_repaired(self):
         raw = json.dumps({
             "family": "math-strategy/clarification-meta",
             "leaf": "",
@@ -145,8 +159,9 @@ class TestResponseParser(unittest.TestCase):
             "rationale": "Triple is single-axis.",
         })
         result = parse_arxiv_pattern_response(raw)
-        self.assertFalse(result["ok"])
-        self.assertIn("clarification-meta", result["error"])
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["collapsed"]["reason"], "other")
+        self.assertIn("clarification-meta-collapsed-synthesized", result["warnings"])
 
     def test_clarification_meta_with_collapsed_ok(self):
         raw = json.dumps({
@@ -172,14 +187,32 @@ class TestResponseParser(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertIn("invalid-family", result["error"])
 
-    def test_invalid_leaf_rejected_for_strategic_family(self):
+    def test_invalid_leaf_is_normalized_to_uncertain_for_strategic_family(self):
         raw = json.dumps({
             "family": "math-strategy/existence-result",
             "leaf": "math-informal/imaginary-leaf",
+            "leaf_confidence": 0.9,
         })
         result = parse_arxiv_pattern_response(raw)
-        self.assertFalse(result["ok"])
-        self.assertIn("invalid-leaf", result["error"])
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["leaf"], "uncertain")
+        self.assertLessEqual(result["leaf_confidence"], 0.5)
+        self.assertIn("invalid-leaf-normalized", result["warnings"][0])
+
+    def test_tex_backslashes_in_rationale_are_repaired(self):
+        raw = (
+            '{'
+            '"family": "math-strategy/characterization-result",'
+            '"leaf": "math-informal/structural-characterization",'
+            '"family_confidence": 0.9,'
+            '"leaf_confidence": 0.8,'
+            '"rationale": "Classifies $(\\mathbb{T},\\mathsf{V})$-categories.",'
+            '"collapsed": null'
+            '}'
+        )
+        result = parse_arxiv_pattern_response(raw)
+        self.assertTrue(result["ok"])
+        self.assertIn("\\mathbb", result["rationale"])
 
     def test_no_json_in_response(self):
         result = parse_arxiv_pattern_response("Sorry, I cannot answer.")

--- a/tests/test_arxiv_pattern_prompt.py
+++ b/tests/test_arxiv_pattern_prompt.py
@@ -10,11 +10,15 @@ from __future__ import annotations
 
 import json
 import os
+import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
+import futon6.arxiv_pattern_prompt as arxiv_pattern_prompt
 from futon6.arxiv_pattern_prompt import (
     FAMILY_PARENTS,
+    _default_futon3_library,
     build_arxiv_pattern_prompt,
     load_paper_shape_taxonomy,
     parse_arxiv_pattern_response,
@@ -79,6 +83,28 @@ class TestTaxonomyLoad(unittest.TestCase):
         for leaf_id, expected_family in expected.items():
             self.assertIn(leaf_id, tax.leaves, f"missing new leaf {leaf_id}")
             self.assertEqual(tax.leaves[leaf_id].family, expected_family)
+
+    def test_default_library_finds_sibling_checkout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_root = Path(tmp) / "futon6"
+            fake_module = repo_root / "src" / "futon6" / "arxiv_pattern_prompt.py"
+            fake_module.parent.mkdir(parents=True, exist_ok=True)
+            fake_module.write_text("# fake module path for resolver test\n", encoding="utf-8")
+
+            sibling_library = repo_root / "futon3" / "library"
+            sibling_library.mkdir(parents=True, exist_ok=True)
+            for parent_id in FAMILY_PARENTS:
+                (sibling_library / f"{parent_id}.flexiarg").parent.mkdir(parents=True, exist_ok=True)
+                (sibling_library / f"{parent_id}.flexiarg").write_text("title: ok\n", encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with mock.patch.object(
+                    arxiv_pattern_prompt,
+                    "DEFAULT_FUTON3_LIBRARY",
+                    repo_root / "missing-home-library",
+                ):
+                    with mock.patch.object(arxiv_pattern_prompt, "__file__", str(fake_module)):
+                        self.assertEqual(_default_futon3_library(), sibling_library)
 
 
 @unittest.skipUnless(_HAS_LIBRARY, "futon3 library not present")

--- a/tests/test_graph_embed.py
+++ b/tests/test_graph_embed.py
@@ -12,6 +12,7 @@ from futon6.graph_embed import (
     augment_graph,
     ThreadGNN,
     info_nce_loss,
+    _shutdown_dataloader_workers,
     train,
     save_tensor_cache,
     load_tensor_cache,
@@ -142,3 +143,24 @@ def test_train_with_tensor_cache(sample_hg, tmp_path):
         epochs=2, batch_size=2, verbose=False,
         tensor_cache_path=cache_path)
     assert emb2.shape == emb1.shape
+
+
+def test_shutdown_dataloader_workers_clears_loader_iterator():
+    class FakeIterator:
+        def __init__(self):
+            self.shutdown_calls = 0
+
+        def _shutdown_workers(self):
+            self.shutdown_calls += 1
+
+    class FakeLoader:
+        def __init__(self, iterator):
+            self._iterator = iterator
+
+    iterator = FakeIterator()
+    loader = FakeLoader(iterator)
+
+    _shutdown_dataloader_workers(loader)
+
+    assert iterator.shutdown_calls == 1
+    assert loader._iterator is None

--- a/tests/test_superpod_job_loader_cleanup.py
+++ b/tests/test_superpod_job_loader_cleanup.py
@@ -1,0 +1,50 @@
+"""Regression tests for explicit DataLoader worker cleanup in superpod-job."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _load_superpod_job():
+    root = Path(__file__).parent.parent
+    sys.path.insert(0, str(root / "scripts"))
+    return importlib.import_module("superpod-job")
+
+
+class _FakeIterator:
+    def __init__(self):
+        self.shutdown_calls = 0
+
+    def _shutdown_workers(self):
+        self.shutdown_calls += 1
+
+
+class _FakeLoader:
+    def __init__(self, iterator):
+        self._iterator = iterator
+
+
+def test_shutdown_dataloader_workers_shuts_down_loader_iterator():
+    mod = _load_superpod_job()
+    iterator = _FakeIterator()
+    loader = _FakeLoader(iterator)
+
+    mod._shutdown_dataloader_workers(loader)
+
+    assert iterator.shutdown_calls == 1
+    assert loader._iterator is None
+
+
+def test_shutdown_dataloader_workers_prefers_explicit_iterator():
+    mod = _load_superpod_job()
+    loader_iterator = _FakeIterator()
+    explicit_iterator = _FakeIterator()
+    loader = _FakeLoader(loader_iterator)
+
+    mod._shutdown_dataloader_workers(loader, explicit_iterator)
+
+    assert explicit_iterator.shutdown_calls == 1
+    assert loader_iterator.shutdown_calls == 0
+    assert loader._iterator is None

--- a/tests/test_superpod_job_smoke.py
+++ b/tests/test_superpod_job_smoke.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
+from types import SimpleNamespace
 from pathlib import Path
 
 
@@ -70,28 +72,48 @@ def _run_arxiv_superpod(
     )
 
 
-def _write_arxiv_fixture(input_dir: Path) -> Path:
+def _load_superpod_job_module(root: Path):
+    spec = importlib.util.spec_from_file_location(
+        "superpod_job_for_test",
+        root / "scripts" / "superpod-job.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_arxiv_fixture(input_dir: Path, *, count: int = 1) -> Path:
     input_dir.mkdir()
     eprints = input_dir / "eprints"
     eprints.mkdir()
-    (input_dir / "batch-001.jsonl").write_text(
-        json.dumps({
-            "id": "math/0102067v1",
-            "title": "A toy theorem",
-            "abstract": "We prove that $x=x$ by a short argument.",
-            "categories": ["math.CT"],
-            "date": "2001-02-07",
-        }) + "\n",
-        encoding="utf-8",
-    )
-    (eprints / "math__0102067v1.tex").write_text(
-        "\\documentclass{article}\n"
-        "\\begin{document}\n"
-        "\\begin{theorem}For every object $X$, $X=X$.\\end{theorem}\n"
-        "\\begin{proof}Use the identity morphism $1_X:X\\to X$.\\end{proof}\n"
-        "\\end{document}\n",
-        encoding="utf-8",
-    )
+    rows = []
+    for idx in range(count):
+        numeric = 102067 + idx
+        arxiv_id = f"math/{numeric:07d}v1"
+        rows.append(
+            json.dumps(
+                {
+                    "id": arxiv_id,
+                    "title": f"A toy theorem {idx + 1}",
+                    "abstract": f"We prove that $x_{idx + 1}=x_{idx + 1}$ by a short argument.",
+                    "categories": ["math.CT"],
+                    "date": "2001-02-07",
+                }
+            )
+        )
+        (eprints / f"math__{numeric:07d}v1.tex").write_text(
+            "\\documentclass{article}\n"
+            "\\begin{document}\n"
+            f"\\begin{{theorem}}For every object $X_{{{idx + 1}}}$, "
+            f"$X_{{{idx + 1}}}=X_{{{idx + 1}}}$.\\end{{theorem}}\n"
+            f"\\begin{{proof}}Use the identity morphism $1_{{X_{{{idx + 1}}}}}:"
+            f"X_{{{idx + 1}}}\\to X_{{{idx + 1}}}$.\\end{{proof}}\n"
+            "\\end{document}\n",
+            encoding="utf-8",
+        )
+    (input_dir / "batch-001.jsonl").write_text("\n".join(rows) + "\n", encoding="utf-8")
     return eprints
 
 
@@ -202,8 +224,13 @@ def test_arxiv_paper_eprint_dir_feeds_all_paper_stages(tmp_path: Path):
     geometry = json.loads((outdir / "geometry.json").read_text(encoding="utf-8"))
     assert isinstance(geometry, list)
     assert geometry[0]["paper_id"].startswith("arxiv-")
+    assert geometry[0]["n_claims"] == 1
+    assert geometry[0]["T_total"] >= 0
     assert "laplacian_summary" in geometry[0]
     assert manifest["stage9a_stats"]["geometry_stats"]["papers"] == 1
+    assert manifest["stage9a_stats"]["geometry_stats"]["with_claims"] == 1
+    assert manifest["stage9a_stats"]["geometry_source"] == "paper-hypergraphs"
+    assert manifest["stage_status"]["hypergraphs"]["geometry_with_claims"] == 1
 
 
 def test_arxiv_batch_local_eprints_auto_default(tmp_path: Path):
@@ -225,6 +252,8 @@ def test_arxiv_batch_local_eprints_auto_default(tmp_path: Path):
     assert manifest["paper_eprint_dir"] == str(eprints.resolve())
     assert manifest["paper_eprint"]["source"] == "discover-terms-eprint-dir-default"
     assert manifest["stage9a_stats"]["eprint_text_used"] == 1
+    assert manifest["stage9a_stats"]["geometry_source"] == "paper-hypergraphs"
+    assert manifest["stage9a_stats"]["geometry_stats"]["with_claims"] == 1
     assert (outdir / "geometry.json").exists()
 
 
@@ -250,6 +279,9 @@ def test_arxiv_legacy_theorem_aliases_are_normalized(tmp_path: Path):
     assert len(claim_nodes) == 1
     assert claim_nodes[0]["attrs"]["block_origin"] == "alias_expanded"
     assert "newtheorem alias thm->theorem" in claim_nodes[0]["attrs"]["source_cue"]
+    geometry = json.loads((outdir / "geometry.json").read_text(encoding="utf-8"))
+    assert geometry[0]["n_claims"] == 1
+    assert manifest["stage9a_stats"]["geometry_source"] == "paper-hypergraphs"
 
 
 def test_arxiv_paper_hg_eprint_dir_is_legacy_alias(tmp_path: Path):
@@ -317,3 +349,295 @@ def test_arxiv_moist_run_uses_paper_shape_prompt(tmp_path: Path):
     assert "mathematics paper-shape classifier" in prompt
     assert "math-strategy/" in prompt
     assert "math.stackexchange" not in prompt
+
+
+def test_stage3_existing_arxiv_chunks_reparse_when_parser_version_changes(tmp_path: Path):
+    root = Path(__file__).parent.parent
+    module = _load_superpod_job_module(root)
+    outdir = tmp_path / "arxiv-out"
+    chunk_dir = outdir / "stage3-pattern-tags-chunks"
+    chunk_dir.mkdir(parents=True)
+    old_meta = {
+        "version": 1,
+        "total_pairs": 1,
+        "chunks_per_shard": 1,
+        "effective_chunks": 1,
+        "max_new_tokens": 192,
+    }
+    (chunk_dir / "meta.json").write_text(
+        json.dumps(old_meta, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    raw = (
+        '{'
+        '"family": "math-strategy/characterization-result",'
+        '"leaf": "math-informal/structural-characterization",'
+        '"family_confidence": 0.9,'
+        '"leaf_confidence": 0.8,'
+        '"rationale": "Classifies $(\\mathbb{T},\\mathsf{V})$-categories.",'
+        '"collapsed": null'
+        '}'
+    )
+    (chunk_dir / "chunk-000.json").write_text(
+        json.dumps(
+            [
+                {
+                    "entry_id": "arxiv-math/0102067v1",
+                    "status": "failed",
+                    "reason": "stage3-parse-error",
+                    "error": "json-decode: Invalid \\\\escape",
+                    "patterns": [],
+                    "raw": raw,
+                }
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class FailIfCalledPool:
+        def run_stage3(self, items, batch_size):
+            raise AssertionError("Stage 3 LLM should not rerun existing chunks")
+
+    pairs = [
+        SimpleNamespace(
+            question=SimpleNamespace(title="A toy paper", body_text="abstract"),
+            answer=SimpleNamespace(body_text="abstract"),
+        )
+    ]
+    results = module.run_stage3_pattern_tagging_chunked(
+        pairs,
+        ["arxiv-math/0102067v1"],
+        outdir,
+        pipe=None,
+        tokenizer=None,
+        batch_size=1,
+        chunks_per_shard=1,
+        llm_pool=FailIfCalledPool(),
+        max_new_tokens=192,
+    )
+
+    assert results[0]["status"] == "ok"
+    assert "\\mathbb" in results[0]["rationale"]
+    meta = json.loads((chunk_dir / "meta.json").read_text(encoding="utf-8"))
+    assert meta["parse_version"] == "arxiv-paper-shapes-v2"
+    merged = json.loads((outdir / "pattern-tags.json").read_text(encoding="utf-8"))
+    assert merged[0]["status"] == "ok"
+
+
+def test_arxiv_paper_stage_resume_survives_missing_manifest_via_stage_sidecars(tmp_path: Path):
+    root = Path(__file__).parent.parent
+    input_dir = tmp_path / "arxiv-input"
+    _write_arxiv_fixture(input_dir)
+    outdir = tmp_path / "arxiv-out"
+
+    first = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        [
+            "--paper-eprint-dir",
+            "eprints",
+            "--llm-stage5d-checkpoint-chunk-size",
+            "32",
+        ],
+    )
+    assert first.returncode == 0, (
+        "initial superpod-job arxiv eprint run failed\n"
+        f"stdout:\n{first.stdout}\n"
+        f"stderr:\n{first.stderr}"
+    )
+
+    manifest_path = outdir / "manifest.json"
+    manifest_path.unlink()
+    assert not manifest_path.exists()
+    assert (outdir / "stage-status" / "technique_ner.json").exists()
+    assert (outdir / "stage-status" / "paper_hypergraph.json").exists()
+
+    second = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        [
+            "--paper-eprint-dir",
+            "eprints",
+            "--llm-stage5d-checkpoint-chunk-size",
+            "32",
+        ],
+    )
+    assert second.returncode == 0, (
+        "resumed superpod-job arxiv eprint run failed\n"
+        f"stdout:\n{second.stdout}\n"
+        f"stderr:\n{second.stderr}"
+    )
+    assert "Reusing existing techniques.json" in second.stdout
+    assert "Reusing existing paper-hypergraphs.json" in second.stdout
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["stage_status"]["technique_ner"]["resumed"] is True
+    assert manifest["stage_status"]["paper_hypergraph"]["resumed"] is True
+    assert manifest["stage_status"]["technique_ner"]["text_source_counts"]["eprint"] == 1
+    assert manifest["stage_status"]["paper_hypergraph"]["text_source_counts"]["eprint"] == 1
+
+    manifest_path.unlink()
+
+    third = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        ["--paper-eprint-dir", "eprints"],
+    )
+    assert third.returncode == 0, (
+        "repeat resumed superpod-job arxiv eprint run failed\n"
+        f"stdout:\n{third.stdout}\n"
+        f"stderr:\n{third.stderr}"
+    )
+    assert "Reusing existing techniques.json" in third.stdout
+    assert "Reusing existing paper-hypergraphs.json" in third.stdout
+
+
+def test_arxiv_paper_stage_resume_requires_stage_sidecar_provenance(tmp_path: Path):
+    root = Path(__file__).parent.parent
+    input_dir = tmp_path / "arxiv-input"
+    _write_arxiv_fixture(input_dir)
+    outdir = tmp_path / "arxiv-out"
+
+    first = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        [
+            "--paper-eprint-dir",
+            "eprints",
+            "--llm-stage5d-checkpoint-chunk-size",
+            "32",
+        ],
+    )
+    assert first.returncode == 0, (
+        "initial superpod-job arxiv eprint run failed\n"
+        f"stdout:\n{first.stdout}\n"
+        f"stderr:\n{first.stderr}"
+    )
+
+    (outdir / "manifest.json").unlink()
+    (outdir / "stage-status" / "technique_ner.json").unlink()
+
+    second = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        [
+            "--paper-eprint-dir",
+            "eprints",
+            "--llm-stage5d-checkpoint-chunk-size",
+            "32",
+        ],
+    )
+    assert second.returncode != 0
+    assert "Stage 5c cannot safely resume existing techniques.json" in second.stderr
+    assert "Move" in second.stderr
+    assert "fresh provenance" in second.stderr
+
+
+def test_arxiv_paper_stage5d_chunk_resume_reuses_completed_chunks(tmp_path: Path):
+    root = Path(__file__).parent.parent
+    input_dir = tmp_path / "arxiv-input"
+    _write_arxiv_fixture(input_dir, count=33)
+    outdir = tmp_path / "arxiv-out"
+
+    first = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        [
+            "--paper-eprint-dir",
+            "eprints",
+            "--llm-stage5d-checkpoint-chunk-size",
+            "32",
+        ],
+    )
+    assert first.returncode == 0, (
+        "initial superpod-job arxiv stage5d run failed\n"
+        f"stdout:\n{first.stdout}\n"
+        f"stderr:\n{first.stderr}"
+    )
+
+    chunk_dir = outdir / "stage5d-paper-hypergraph-chunks"
+    assert (chunk_dir / "chunk-000.json").exists()
+    assert (chunk_dir / "chunk-001.json").exists()
+
+    (outdir / "manifest.json").unlink()
+    (outdir / "stage-status" / "paper_hypergraph.json").unlink()
+    (outdir / "paper-hypergraphs.json").unlink()
+    (chunk_dir / "chunk-001.json").unlink()
+
+    second = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        [
+            "--paper-eprint-dir",
+            "eprints",
+            "--llm-stage5d-checkpoint-chunk-size",
+            "32",
+        ],
+    )
+    assert second.returncode == 0, (
+        "resumed superpod-job arxiv stage5d run failed\n"
+        f"stdout:\n{second.stdout}\n"
+        f"stderr:\n{second.stderr}"
+    )
+    assert "Stage 5d chunking: 2 chunks" in second.stdout
+    assert "chunk 1/2 exists (32 papers), skipping" in second.stdout
+    assert "chunk 2/2:" in second.stdout
+    assert "chunk 2/2 written: chunk-001.json" in second.stdout
+
+    manifest = json.loads((outdir / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["stage_status"]["paper_hypergraph"]["resumed_from_chunks"] is True
+    assert manifest["stage_status"]["paper_hypergraph"]["resumed_chunks"] == 1
+    assert manifest["stage_status"]["paper_hypergraph"]["resumed_papers"] == 32
+
+
+def test_arxiv_paper_stage5d_resume_keeps_existing_chunk_geometry_when_default_changes(tmp_path: Path):
+    root = Path(__file__).parent.parent
+    input_dir = tmp_path / "arxiv-input"
+    _write_arxiv_fixture(input_dir, count=33)
+    outdir = tmp_path / "arxiv-out"
+
+    first = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        [
+            "--paper-eprint-dir",
+            "eprints",
+            "--llm-stage5d-checkpoint-chunk-size",
+            "32",
+        ],
+    )
+    assert first.returncode == 0, (
+        "initial superpod-job arxiv stage5d geometry run failed\n"
+        f"stdout:\n{first.stdout}\n"
+        f"stderr:\n{first.stderr}"
+    )
+
+    chunk_dir = outdir / "stage5d-paper-hypergraph-chunks"
+    (outdir / "manifest.json").unlink()
+    (outdir / "stage-status" / "paper_hypergraph.json").unlink()
+    (outdir / "paper-hypergraphs.json").unlink()
+    (chunk_dir / "chunk-001.json").unlink()
+
+    second = _run_arxiv_superpod(
+        root,
+        outdir,
+        input_dir,
+        ["--paper-eprint-dir", "eprints"],
+    )
+    assert second.returncode == 0, (
+        "resumed superpod-job arxiv stage5d geometry-preserving run failed\n"
+        f"stdout:\n{second.stdout}\n"
+        f"stderr:\n{second.stderr}"
+    )
+    assert "Reusing existing Stage 5d checkpoint geometry (32 papers/chunk)" in second.stdout
+    assert "Stage 5d chunking: 2 chunks" in second.stdout
+    assert "chunk 1/2 exists (32 papers), skipping" in second.stdout


### PR DESCRIPTION
## Summary

- Harden SuperPOD arXiv batch delivery validation so bad stage outputs are caught before delivery.
- Rework Stage 3 extraction/reparse handling for raw chunk artifacts, TeX JSON escapes, invalid leaves, and missing clarification metadata.
- Add Stage 6 reuse/precheck behavior and geometry sourcing from `paper-hypergraphs`.
- Clean up graph embedding behavior and add regression coverage for loader cleanup, arXiv pattern prompts, graph embedding, and SuperPOD smoke paths.

## Validation

```text
/users/rjmeyers/gh/mfuton/agent_skills/development/codex-python12.sh -m pytest tests/test_superpod_job_smoke.py tests/test_superpod_job_loader_cleanup.py tests/test_arxiv_pattern_prompt.py tests/test_graph_embed.py -q
41 passed, 12 warnings in 113.04s
```
