### PR TITLE
Superpod CT run fixes and GPU guard

### DIFF
--- a/scripts/handoff-superpod-all.sh
+++ b/scripts/handoff-superpod-all.sh
@@ -59,7 +59,7 @@ echo() {
 #   LLM_STAGE6_BATCH_SIZE  Stage 6 LLM batch size (default: 48)
 #   LLM_STAGE6_CHUNKS_PER_SHARD  Stage 6 resumable chunks per shard (default: 10)
 #   LLM_GPU_WORKERS       Replica-fanout local LLM GPU workers, not DDP/DeepSpeed
-#                          (default: 0 = auto all visible GPUs)
+#                          (default: current Slurm current-host GPU count)
 #   LLM_LOADER_WORKERS     Python workers feeding Dataset-backed LLM pipelines.
 #                          Unsharded superpod-job defaults to min(16,
 #                          Slurm/cpuset CPU affinity). Sharded superpod-shard
@@ -78,6 +78,8 @@ echo() {
 # ~/~ begin <<data/first-proof/superpod-handoff-rob.lit.md#all-root-and-args>>[init]
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
+# shellcheck source=scripts/mfuton-superpod-gpu-policy.sh
+source "$ROOT_DIR/scripts/mfuton-superpod-gpu-policy.sh"
 
 SMOKE_ONLY=0
 SKIP_BOOTSTRAP=0
@@ -91,7 +93,8 @@ LLM_STAGE3_BATCH_SIZE="${LLM_STAGE3_BATCH_SIZE:-80}"
 LLM_STAGE3_CHUNKS_PER_SHARD="${LLM_STAGE3_CHUNKS_PER_SHARD:-10}"
 LLM_STAGE6_BATCH_SIZE="${LLM_STAGE6_BATCH_SIZE:-48}"
 LLM_STAGE6_CHUNKS_PER_SHARD="${LLM_STAGE6_CHUNKS_PER_SHARD:-10}"
-LLM_GPU_WORKERS="${LLM_GPU_WORKERS:-0}"
+mfuton_superpod_apply_gpu_policy
+LLM_GPU_WORKERS="${LLM_GPU_WORKERS:-$MFUTON_SUPERPOD_GPU_COUNT}"
 GRAPH_EMBED_DIM="${GRAPH_EMBED_DIM:-128}"
 GRAPH_EMBED_EPOCHS="${GRAPH_EMBED_EPOCHS:-50}"
 GRAPH_EMBED_BATCH_SIZE="${GRAPH_EMBED_BATCH_SIZE:-1024}"
@@ -302,6 +305,7 @@ if [[ "$BLOCK" == "2" ]]; then
     --skip-post-merge \
     -- --thread-limit "$LLM_THREAD_LIMIT" --skip-embeddings \
     --llm-model "$LLM_MODEL" --embed-device cuda \
+    --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
     --llm-batch-size "$LLM_BATCH_SIZE" \
     --llm-stage3-batch-size "$LLM_STAGE3_BATCH_SIZE" \
     --llm-stage3-chunks-per-shard "$LLM_STAGE3_CHUNKS_PER_SHARD" \
@@ -319,6 +323,7 @@ if [[ "$BLOCK" == "2" ]]; then
     --skip-post-merge \
     -- --thread-limit "$LLM_THREAD_LIMIT" --skip-embeddings \
     --llm-model "$LLM_MODEL" --embed-device cuda \
+    --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
     --llm-batch-size "$LLM_BATCH_SIZE" \
     --llm-stage3-batch-size "$LLM_STAGE3_BATCH_SIZE" \
     --llm-stage3-chunks-per-shard "$LLM_STAGE3_CHUNKS_PER_SHARD" \

--- a/scripts/handoff-superpod-gpu-backfill.sh
+++ b/scripts/handoff-superpod-gpu-backfill.sh
@@ -28,7 +28,7 @@ echo() {
 #   LLM_STAGE6_BATCH_SIZE  Stage 6 LLM batch size (default: 48)
 #   LLM_STAGE6_CHUNKS_PER_SHARD  Stage 6 resumable chunks per shard (default: 10)
 #   LLM_GPU_WORKERS       Replica-fanout local LLM GPU workers, not DDP/DeepSpeed
-#                          (default: 0 = auto all visible GPUs)
+#                          (default: current Slurm current-host GPU count)
 #   LLM_LOADER_WORKERS     Python workers feeding Dataset-backed LLM pipelines.
 #                          For unsharded runs, superpod-job defaults to
 #                          min(16, Slurm/cpuset CPU affinity). For sharded
@@ -42,6 +42,9 @@ echo() {
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
+# shellcheck source=scripts/mfuton-superpod-gpu-policy.sh
+source "$ROOT_DIR/scripts/mfuton-superpod-gpu-policy.sh"
+mfuton_superpod_apply_gpu_policy
 
 TARGET="${1:-both}"
 case "$TARGET" in
@@ -60,7 +63,7 @@ if ! command -v nvidia-smi >/dev/null 2>&1; then
   exit 1
 fi
 
-nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader
+nvidia-smi -i "$CUDA_VISIBLE_DEVICES" --query-gpu=name,memory.total,driver_version --format=csv,noheader
 echo
 
 if ! python3 -c "import torch; assert torch.cuda.is_available(), 'no CUDA'" 2>/dev/null; then
@@ -83,7 +86,7 @@ LLM_STAGE3_BATCH_SIZE="${LLM_STAGE3_BATCH_SIZE:-80}"
 LLM_STAGE3_CHUNKS_PER_SHARD="${LLM_STAGE3_CHUNKS_PER_SHARD:-10}"
 LLM_STAGE6_BATCH_SIZE="${LLM_STAGE6_BATCH_SIZE:-48}"
 LLM_STAGE6_CHUNKS_PER_SHARD="${LLM_STAGE6_CHUNKS_PER_SHARD:-10}"
-LLM_GPU_WORKERS="${LLM_GPU_WORKERS:-0}"
+LLM_GPU_WORKERS="${LLM_GPU_WORKERS:-$MFUTON_SUPERPOD_GPU_COUNT}"
 EMBED_MODEL="${EMBED_MODEL:-BAAI/bge-large-en-v1.5}"
 GRAPH_EMBED_DIM="${GRAPH_EMBED_DIM:-128}"
 GRAPH_EMBED_EPOCHS="${GRAPH_EMBED_EPOCHS:-50}"
@@ -115,6 +118,7 @@ run_site() {
     --output-dir "$outdir" \
     --embed-device cuda \
     --embed-model "$EMBED_MODEL" \
+    --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
     --llm-model "$LLM_MODEL" \
     --llm-batch-size "$LLM_BATCH_SIZE" \
     --llm-stage3-batch-size "$LLM_STAGE3_BATCH_SIZE" \
@@ -153,6 +157,7 @@ run_site_sharded() {
     -- \
     --embed-device cuda \
     --embed-model "$EMBED_MODEL" \
+    --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
     --llm-model "$LLM_MODEL" \
     --llm-batch-size "$LLM_BATCH_SIZE" \
     --llm-stage3-batch-size "$LLM_STAGE3_BATCH_SIZE" \

--- a/scripts/mfuton-superpod-gpu-policy.sh
+++ b/scripts/mfuton-superpod-gpu-policy.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Superpod GPU policy gate for futon6 launchers.
+#
+# Authority lives in mfuton:
+#   agent_skills/development/superpod/current-job-gpus.sh
+#
+# This helper fails fast if the current Slurm job allocation cannot be resolved.
+# It exports CUDA_VISIBLE_DEVICES to exactly the current-host GPU IDs Slurm
+# allocated to the job. On dev/short partitions that must be a single GPU.
+
+mfuton_superpod_find_home() {
+  if [[ -n "${MFUTON_HOME:-}" ]]; then
+    printf '%s\n' "$MFUTON_HOME"
+    return 0
+  fi
+
+  local candidate
+  for candidate in \
+    "$HOME/gh/mfuton" \
+    "/users/rjmeyers/gh/mfuton" \
+    "/home/rjmeyers/gh/mfuton"
+  do
+    if [[ -x "$candidate/agent_skills/development/superpod/current-job-gpus.sh" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  echo "[gpu-policy] FATAL: MFUTON_HOME is unset and mfuton was not found in known locations." >&2
+  return 1
+}
+
+mfuton_superpod_apply_gpu_policy() {
+  local requested="${1:-slurm-current-job}"
+  local mfuton_home
+  mfuton_home="$(mfuton_superpod_find_home)"
+
+  local skill="$mfuton_home/agent_skills/development/superpod/current-job-gpus.sh"
+  if [[ ! -x "$skill" ]]; then
+    echo "[gpu-policy] FATAL: GPU allocation skill is not executable: $skill" >&2
+    return 1
+  fi
+
+  local info_json
+  if ! info_json="$(MFUTON_HOME="$mfuton_home" "$skill" --format json --request "$requested")"; then
+    echo "[gpu-policy] FATAL: failed to resolve current Slurm GPU allocation." >&2
+    echo "$info_json" >&2
+    return 1
+  fi
+
+  local parsed
+  if ! parsed="$(GPU_INFO_JSON="$info_json" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["GPU_INFO_JSON"])
+if not payload.get("ok"):
+    raise SystemExit(payload.get("error") or "GPU allocation skill returned ok=false")
+
+ids = payload.get("selected_gpu_ids")
+if ids is None:
+    ids = payload.get("current_host_gpu_ids")
+if not isinstance(ids, list) or not ids:
+    raise SystemExit(f"no current-host GPU IDs in allocation payload: {payload!r}")
+if not all(isinstance(value, int) and value >= 0 for value in ids):
+    raise SystemExit(f"invalid GPU ID list in allocation payload: {ids!r}")
+
+partition = str(payload.get("partition") or "")
+if partition.rstrip("*").lower() in {"short", "dev"} and len(ids) != 1:
+    raise SystemExit(
+        f"policy violation: partition {partition!r} must expose exactly one GPU, got {ids}"
+    )
+
+print(",".join(str(value) for value in ids))
+print(str(len(ids)))
+print(partition)
+print(str(payload.get("job_id") or ""))
+print(str(payload.get("current_host") or ""))
+PY
+  )"; then
+    echo "[gpu-policy] FATAL: invalid current Slurm GPU allocation payload." >&2
+    echo "$info_json" >&2
+    return 1
+  fi
+
+  local gpu_ids gpu_count partition job_id current_host
+  gpu_ids="$(sed -n '1p' <<<"$parsed")"
+  gpu_count="$(sed -n '2p' <<<"$parsed")"
+  partition="$(sed -n '3p' <<<"$parsed")"
+  job_id="$(sed -n '4p' <<<"$parsed")"
+  current_host="$(sed -n '5p' <<<"$parsed")"
+
+  export CUDA_VISIBLE_DEVICES="$gpu_ids"
+  export MFUTON_SUPERPOD_GPU_IDS="$gpu_ids"
+  export MFUTON_SUPERPOD_GPU_COUNT="$gpu_count"
+  export MFUTON_SUPERPOD_PARTITION="$partition"
+  export MFUTON_SUPERPOD_JOB_ID="$job_id"
+  export MFUTON_SUPERPOD_HOST="$current_host"
+
+  echo "[gpu-policy] job=$job_id partition=$partition host=$current_host CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES count=$gpu_count"
+}

--- a/scripts/run-arxiv-handoff.sh
+++ b/scripts/run-arxiv-handoff.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/mfuton-superpod-gpu-policy.sh
+source "$ROOT_DIR/scripts/mfuton-superpod-gpu-policy.sh"
 
 # Override via env if desired.
 SCRATCH_ROOT="${SCRATCH_ROOT:-$HOME/gh/scratch/darktower/futon6}"
@@ -39,6 +41,7 @@ unpack_bundle() {
 
 run_arxiv_pipeline() {
   step "Run arXiv math.CT pipeline"
+  mfuton_superpod_apply_gpu_policy
   if [[ "$NUM_SHARDS" -gt 1 ]]; then
     echo "[note] arXiv pipeline runs unsharded; NUM_SHARDS=$NUM_SHARDS is ignored."
   fi
@@ -55,6 +58,8 @@ run_arxiv_pipeline() {
       --output-dir "$OUT_DIR" \
       --input-dir "$SCRATCH_ROOT" \
       --limit 10000 \
+      --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
+      --llm-gpu-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
       --skip-llm --skip-clustering --skip-threads --skip-expressions \
       --paper-hg-eprint-dir data/arxiv-math-ct-eprints \
       --discover-terms \
@@ -73,6 +78,7 @@ run_se_pipeline() {
   fi
 
   step "Run StackExchange pipeline (new-term spotting)"
+  mfuton_superpod_apply_gpu_policy
   if [[ "$NUM_SHARDS" -gt 1 ]]; then
     (
       cd "$ROOT_DIR"
@@ -82,6 +88,8 @@ run_se_pipeline() {
         --num-shards "$NUM_SHARDS" \
         --output-dir "$se_outdir" \
         -- \
+        --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
+        --llm-gpu-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
         --discover-terms
     )
   else
@@ -89,6 +97,8 @@ run_se_pipeline() {
       cd "$ROOT_DIR"
       python3 "$ROOT_DIR/scripts/superpod-job.py" "$posts_xml" \
         --output-dir "$se_outdir" \
+        --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
+        --llm-gpu-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
         --discover-terms
     )
   fi
@@ -104,6 +114,7 @@ run_mo_pipeline() {
   fi
 
   step "Run MathOverflow pipeline (new-term spotting)"
+  mfuton_superpod_apply_gpu_policy
   if [[ "$NUM_SHARDS" -gt 1 ]]; then
     (
       cd "$ROOT_DIR"
@@ -113,6 +124,8 @@ run_mo_pipeline() {
         --num-shards "$NUM_SHARDS" \
         --output-dir "$mo_outdir" \
         -- \
+        --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
+        --llm-gpu-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
         --discover-terms
     )
   else
@@ -121,6 +134,8 @@ run_mo_pipeline() {
       python3 "$ROOT_DIR/scripts/superpod-job.py" "$mo_posts_xml" \
         --site mathoverflow.net \
         --output-dir "$mo_outdir" \
+        --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
+        --llm-gpu-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
         --discover-terms
     )
   fi

--- a/scripts/setup-ct-run.sh
+++ b/scripts/setup-ct-run.sh
@@ -20,6 +20,10 @@
 # configured (HostName 172.236.108.82, port 2222, user rob) ; nnexus at ~/code/nnexus.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/mfuton-superpod-gpu-policy.sh
+source "$SCRIPT_DIR/mfuton-superpod-gpu-policy.sh"
+
 REPO="${REPO:-$HOME/code/futon6}"
 STORE="${STORE:-$HOME/code/storage/futon6/data}"
 REMOTE="${REMOTE:-linode-chicago}"
@@ -64,6 +68,7 @@ do_setup() {
 
 do_run() {
   cd "$REPO"
+  mfuton_superpod_apply_gpu_policy
   echo "== running math.CT GPU pipeline =="
   python3 scripts/superpod-job.py \
     --arxiv-jsonl "$STORE/arxiv-math-ct-metadata.jsonl" \
@@ -80,6 +85,8 @@ do_run() {
     --discover-terms-nnexus-stopwords ../nnexus/lib/NNexus/StopWordList.pm \
     --discover-terms-nnexus-snapshot ../nnexus/lib/NNexus/resources/database/snapshot-6-2014.sqlite \
     --discover-terms-collocation-prior data/ct-term-prior.json \
+    --embed-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
+    --llm-gpu-workers "$MFUTON_SUPERPOD_GPU_COUNT" \
     --stage6-backend codex
   echo "== done. results in ~/code/storage/arxiv-paper-hg-gpu-ct-5k =="
   echo "   collocation gate: see candidate-new-terms-summary.json ->"

--- a/scripts/superpod-job.py
+++ b/scripts/superpod-job.py
@@ -1607,6 +1607,7 @@ def run_stage5_ner_scopes(
     discovery_eprint_ok = 0
     discovery_eprint_missing = 0
     discovery_eprint_status = Counter()
+    discovery_eprint_examples = {}
     discovery_aggregates = {}
     rhs_context_cache = {}
     pm_seed_lowers = set()
@@ -1667,6 +1668,7 @@ def run_stage5_ner_scopes(
     eprint_text_used = 0
     eprint_text_missing = 0
     eprint_status_counts = Counter()
+    eprint_status_examples = {}
     arxiv_entities_processed = 0
     total_learned_structure_matches = 0
     entities_with_learned_structure_matches = 0
@@ -1711,6 +1713,7 @@ def run_stage5_ner_scopes(
             text_source_counts[text_source] += 1
             eprint_status = eprint_meta.get("status", "unknown")
             eprint_status_counts[eprint_status] += 1
+            _record_eprint_diagnostic(eprint_status_examples, eid, eprint_meta)
             if eid.startswith("arxiv-"):
                 arxiv_entities_processed += 1
             if text_source == "eprint":
@@ -1862,6 +1865,7 @@ def run_stage5_ner_scopes(
                     )
                     estatus = e_meta.get("status", "unknown")
                     discovery_eprint_status[estatus] += 1
+                    _record_eprint_diagnostic(discovery_eprint_examples, eid, e_meta)
                     if eprint_text:
                         discovery_text = eprint_text
                         discovery_meta = e_meta
@@ -2251,6 +2255,7 @@ def run_stage5_ner_scopes(
             "eprint_text_used": discovery_eprint_ok,
             "eprint_text_missing": discovery_eprint_missing,
             "eprint_status_counts": dict(discovery_eprint_status),
+            "eprint_status_examples": discovery_eprint_examples,
             "total_extracted": discovery_total,
             "total_unknown_extracted": discovery_unknown,
             "unique_unknown_terms": len(discovery_occ),
@@ -2355,6 +2360,7 @@ def run_stage5_ner_scopes(
         "eprint_text_used": eprint_text_used,
         "eprint_text_missing": eprint_text_missing,
         "eprint_status_counts": dict(eprint_status_counts),
+        "eprint_status_examples": eprint_status_examples,
         "arxiv_entities_processed": arxiv_entities_processed,
         "open_ner": open_ner_stats,
         "learned_structure_matches": total_learned_structure_matches,
@@ -2422,6 +2428,12 @@ def _read_tex_members_from_tar(path, max_chars=240_000, max_members=4):
                 member_names.append(m.name)
                 total_chars += len(text)
             joined = "\n\n".join(chunks)
+            if not joined.strip():
+                return "", {
+                    "status": "empty-tex-members",
+                    "path": str(path),
+                    "members": member_names,
+                }
             return joined[:max_chars], {
                 "status": "ok",
                 "path": str(path),
@@ -2429,6 +2441,30 @@ def _read_tex_members_from_tar(path, max_chars=240_000, max_members=4):
             }
     except (tarfile.TarError, OSError, EOFError) as exc:
         return "", {"status": "tar-read-error", "path": str(path), "error": str(exc)}
+
+
+_EPRINT_DIAGNOSTIC_LIMIT = 20
+
+
+def _compact_eprint_meta(meta):
+    compact = {}
+    for key in ("status", "id", "path", "error", "members", "candidates", "attempts"):
+        if key in meta:
+            compact[key] = meta[key]
+    return compact
+
+
+def _record_eprint_diagnostic(examples, entity_id, meta, limit=_EPRINT_DIAGNOSTIC_LIMIT):
+    status = str(meta.get("status", "unknown"))
+    if status in {"ok", "no-eprint-dir", "non-arxiv-entity"}:
+        return
+    rows = examples.setdefault(status, [])
+    if len(rows) >= limit:
+        return
+    rows.append({
+        "entity_id": entity_id,
+        **_compact_eprint_meta(meta),
+    })
 
 
 def _load_eprint_text_for_entity(eprint_dir, entity_id, max_chars=240_000, max_members=4):
@@ -2439,7 +2475,7 @@ def _load_eprint_text_for_entity(eprint_dir, entity_id, max_chars=240_000, max_m
     sid = _safe_arxiv_id(arxiv_id)
     cands = [p for p in eprint_dir.glob(f"{sid}*") if p.is_file()]
     if not cands:
-        return None, {"status": "missing", "id": arxiv_id}
+        return None, {"status": "missing", "id": arxiv_id, "safe_id": sid}
 
     def _pri(path):
         name = path.name.lower()
@@ -2453,33 +2489,55 @@ def _load_eprint_text_for_entity(eprint_dir, entity_id, max_chars=240_000, max_m
             return 3
         return 9
 
+    attempts = []
     for path in sorted(cands, key=_pri):
         name = path.name.lower()
         if name.endswith(".tex"):
             try:
                 text = path.read_text(encoding="utf-8", errors="ignore")
                 return text[:max_chars], {"status": "ok", "path": str(path), "members": [path.name]}
-            except OSError:
+            except OSError as exc:
+                attempts.append({
+                    "status": "read-error",
+                    "path": str(path),
+                    "error": str(exc),
+                })
                 continue
         if name.endswith(".tar.gz") or name.endswith(".tar"):
             text, meta = _read_tex_members_from_tar(path, max_chars=max_chars, max_members=max_members)
             if text:
                 return text, meta
+            attempts.append(_compact_eprint_meta(meta))
             continue
         if name.endswith(".bin"):
             # Some payloads are mislabeled; try tar decode first, then plain text.
             text, meta = _read_tex_members_from_tar(path, max_chars=max_chars, max_members=max_members)
             if text:
                 return text, meta
+            attempts.append(_compact_eprint_meta(meta))
             try:
                 raw = path.read_bytes()[: max(8192, max_chars * 2)]
                 guess = raw.decode("utf-8", errors="ignore")
                 if "\\documentclass" in guess or "\\begin{" in guess or "$" in guess:
                     return guess[:max_chars], {"status": "ok", "path": str(path), "members": [path.name]}
-            except OSError:
+                attempts.append({
+                    "status": "plain-text-probe-no-tex",
+                    "path": str(path),
+                })
+            except OSError as exc:
+                attempts.append({
+                    "status": "plain-text-read-error",
+                    "path": str(path),
+                    "error": str(exc),
+                })
                 continue
 
-    return None, {"status": "unusable", "id": arxiv_id}
+    return None, {
+        "status": "unusable",
+        "id": arxiv_id,
+        "candidates": [str(p) for p in sorted(cands, key=_pri)[:10]],
+        "attempts": attempts[:10],
+    }
 
 
 def _entity_text_with_eprint_fallback(
@@ -2849,7 +2907,7 @@ def _is_arxiv_entry_id(entry_id) -> bool:
     return str(entry_id or "").startswith("arxiv-")
 
 
-_STAGE3_ARXIV_PARSE_VERSION = "arxiv-paper-shapes-v2"
+_STAGE3_ARXIV_PARSE_VERSION = "arxiv-paper-shapes-v3"
 _STAGE3_SE_PARSE_VERSION = "se-patterns-v1"
 
 
@@ -2912,14 +2970,19 @@ def _stage3_result_from_raw(entry_id, raw):
 
 
 def _can_reparse_stage3_chunks(existing_meta, expected_meta):
-    """True when only the parser version changed, not the LLM chunk geometry."""
+    """True when only parser/generation caps changed, not chunk geometry."""
     if not isinstance(existing_meta, dict):
         return False
     old = dict(existing_meta)
     new = dict(expected_meta)
     old_parse_version = old.pop("parse_version", None)
     new_parse_version = new.pop("parse_version", None)
-    return old == new and old_parse_version != new_parse_version
+    old_max_new_tokens = old.pop("max_new_tokens", None)
+    new_max_new_tokens = new.pop("max_new_tokens", None)
+    return old == new and (
+        old_parse_version != new_parse_version
+        or old_max_new_tokens != new_max_new_tokens
+    )
 
 
 def _reparse_stage3_chunks_from_raw(chunk_ranges, chunk_dir, entry_ids, expected_meta):
@@ -3933,6 +3996,78 @@ def _parse_json_object_response(text):
             return 0
         return sum(1 for k in expected_keys if k in obj)
 
+    def _extract_jsonish_string_field(s, field):
+        pattern = re.compile(rf'"{re.escape(field)}"\s*:\s*"')
+        match = pattern.search(s)
+        if not match:
+            return None, False
+        i = match.end()
+        chars = []
+        escaped = False
+        while i < len(s):
+            ch = s[i]
+            if escaped:
+                if ch == '"':
+                    chars.append('"')
+                elif ch == "\\":
+                    chars.append("\\")
+                elif ch == "u" and i + 4 < len(s):
+                    hex_digits = s[i + 1:i + 5]
+                    if re.fullmatch(r"[0-9a-fA-F]{4}", hex_digits):
+                        chars.append(chr(int(hex_digits, 16)))
+                        i += 4
+                    else:
+                        chars.append("\\" + ch)
+                else:
+                    # LLM outputs often contain LaTeX such as \mathsf or \bS_p,
+                    # which are invalid JSON escapes but should be preserved.
+                    chars.append("\\" + ch)
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                return "".join(chars), True
+            else:
+                chars.append(ch)
+            i += 1
+        if escaped:
+            chars.append("\\")
+        return "".join(chars).strip(), False
+
+    def _salvage_stage6_jsonish_object(s):
+        """Recover Stage 6 top-level fields from truncated JSON-ish output."""
+        if not all(f'"{key}"' in s for key in expected_keys):
+            return None
+
+        parsed = {}
+        complete = True
+        for key in (
+            "xiang_form",
+            "xiang_salience",
+            "arrow_constraint",
+            "situation_S",
+            "roundtrip_check",
+        ):
+            value, closed = _extract_jsonish_string_field(s, key)
+            if value is None:
+                return None
+            parsed[key] = value
+            complete = complete and closed
+
+        quality = {}
+        for key in ("form", "salience", "arrow"):
+            value, closed = _extract_jsonish_string_field(s, key)
+            if value is None:
+                return None
+            quality[key] = value
+            complete = complete and closed
+        parsed["quality"] = quality
+        parsed["_jsonish_salvage"] = {
+            "reason": "stage6-truncated-or-json-escape-repair",
+            "all_string_fields_closed": complete,
+        }
+        return parsed
+
     def _normalize_quotes(s):
         return (s.replace("“", '"')
                  .replace("”", '"')
@@ -4000,13 +4135,16 @@ def _parse_json_object_response(text):
             except json.JSONDecodeError:
                 pass
 
-        # Some model outputs look like Python dicts with single quotes.
-        try:
-            obj = ast.literal_eval(cleaned)
-            if isinstance(obj, dict):
-                return obj
-        except Exception:
-            pass
+        # Some model outputs look like Python dicts with single quotes. Skip
+        # this path for LaTeX-heavy strings so invalid escapes like \mathsf
+        # are handled by the Stage 6 JSON-ish salvage path without warnings.
+        if "\\" not in cleaned:
+            try:
+                obj = ast.literal_eval(cleaned)
+                if isinstance(obj, dict):
+                    return obj
+            except Exception:
+                pass
         return None
 
     text = str(text or "")
@@ -4041,6 +4179,9 @@ def _parse_json_object_response(text):
         tail_score = _score_obj(parsed)
         if tail_score > best_score or (tail_score == best_score and len(tail) > best_len):
             return parsed
+    salvaged = _salvage_stage6_jsonish_object(tail)
+    if salvaged is not None:
+        return salvaged
     if best_obj is not None:
         return best_obj
 
@@ -4059,6 +4200,7 @@ _STAGE6_REQUIRED_KEYS = {
     "situation_S",
     "roundtrip_check",
 }
+_STAGE6_PARSE_VERSION = "reverse-morphogenesis-v3"
 _STAGE6_QUALITY_KEYS = {"form", "salience", "arrow"}
 _STAGE6_SLOT_KEYS = ("xiang_salience", "arrow_constraint", "situation_S")
 _STAGE6_STOPWORDS = {
@@ -4163,6 +4305,9 @@ def _stage6_slot_distinctness(analysis):
 
 def _build_stage6_result(entity_id, question_id, raw_text):
     parsed = _parse_json_object_response(raw_text)
+    salvage = None
+    if isinstance(parsed, dict):
+        salvage = parsed.pop("_jsonish_salvage", None)
     record = {
         "entity_id": entity_id,
         "question_id": question_id,
@@ -4173,6 +4318,8 @@ def _build_stage6_result(entity_id, question_id, raw_text):
         "analysis": parsed if isinstance(parsed, dict) else {"raw": str(raw_text or "")},
         "raw": str(raw_text or ""),
     }
+    if salvage is not None:
+        record["salvage"] = salvage
 
     if not isinstance(parsed, dict):
         record["reason"] = "stage6-invalid-response"
@@ -4229,7 +4376,68 @@ def _stage6_expected_meta(total, chunks_per_shard):
         "total_pairs": total,
         "chunks_per_shard": int(chunks_per_shard),
         "effective_chunks": len(_stage3_chunk_ranges(total, chunks_per_shard)),
+        "parse_version": _STAGE6_PARSE_VERSION,
     }
+
+
+def _can_reparse_stage6_chunks(existing_meta, expected_meta):
+    """True when only the Stage 6 parser version changed."""
+    return _can_reparse_stage3_chunks(existing_meta, expected_meta)
+
+
+def _reparse_stage6_chunks_from_raw(chunk_ranges, chunk_dir, pairs, entities, expected_meta):
+    reparsed_total = 0
+    failed_total = 0
+    for chunk_idx, start, end in chunk_ranges:
+        chunk_path = chunk_dir / f"chunk-{chunk_idx:03d}.json"
+        if not chunk_path.exists():
+            raise RuntimeError(
+                f"Cannot reparse Stage 6 chunk with current parser: {chunk_path} "
+                "is missing. Remove stage6-reverse-morphogenesis-chunks to restart Stage 6."
+            )
+        with open(chunk_path) as f:
+            chunk_data = json.load(f)
+        if not isinstance(chunk_data, list):
+            raise RuntimeError(
+                f"Cannot reparse Stage 6 chunk with current parser: "
+                f"{chunk_path} is not a JSON list."
+            )
+        expected_len = end - start
+        if len(chunk_data) != expected_len:
+            raise RuntimeError(
+                f"Cannot reparse Stage 6 chunk with current parser: {chunk_path} "
+                f"has {len(chunk_data)} rows, expected {expected_len}."
+            )
+
+        reparsed_rows = []
+        for offset, old_row in enumerate(chunk_data):
+            if not isinstance(old_row, dict) or "raw" not in old_row:
+                raise RuntimeError(
+                    f"Cannot reparse Stage 6 chunk with current parser: "
+                    f"{chunk_path} row {offset} has no raw LLM response."
+                )
+            j = start + offset
+            new_row = _build_stage6_result(
+                entities[j]["entity/id"],
+                pairs[j].question.id,
+                old_row.get("raw"),
+            )
+            reparsed_rows.append(new_row)
+            reparsed_total += 1
+            if new_row.get("status") == "failed":
+                failed_total += 1
+
+        tmp_path = chunk_dir / f"chunk-{chunk_idx:03d}.reparse.tmp"
+        with open(tmp_path, "w") as f:
+            json.dump(reparsed_rows, f, ensure_ascii=False)
+        os.replace(tmp_path, chunk_path)
+
+    with open(chunk_dir / "meta.json", "w") as f:
+        json.dump(expected_meta, f, ensure_ascii=False, indent=2)
+    print(
+        "       Reparsed existing Stage 6 chunks with current parser: "
+        f"{reparsed_total - failed_total}/{reparsed_total} parsed"
+    )
 
 
 def _stage6_chunks_available_for_resume(outdir, total, chunks_per_shard):
@@ -4245,7 +4453,11 @@ def _stage6_chunks_available_for_resume(outdir, total, chunks_per_shard):
             existing_meta = json.load(f)
     except (OSError, json.JSONDecodeError):
         return False
-    if existing_meta != _stage6_expected_meta(total, chunks_per_shard):
+    expected_meta = _stage6_expected_meta(total, chunks_per_shard)
+    if (
+        existing_meta != expected_meta
+        and not _can_reparse_stage6_chunks(existing_meta, expected_meta)
+    ):
         return False
     return _all_chunk_files_present(chunk_ranges, chunk_dir)
 
@@ -4391,11 +4603,20 @@ def run_stage6_reverse_morphogenesis_chunked(
         with open(meta_path) as f:
             existing_meta = json.load(f)
         if existing_meta != expected_meta:
-            raise RuntimeError(
-                f"Stage 6 chunk metadata mismatch in {meta_path}. "
-                "Remove stage6-reverse-morphogenesis-chunks to restart Stage 6 chunking "
-                "with new parameters."
-            )
+            if _can_reparse_stage6_chunks(existing_meta, expected_meta):
+                _reparse_stage6_chunks_from_raw(
+                    chunk_ranges,
+                    chunk_dir,
+                    pairs,
+                    entities,
+                    expected_meta,
+                )
+            else:
+                raise RuntimeError(
+                    f"Stage 6 chunk metadata mismatch in {meta_path}. "
+                    "Remove stage6-reverse-morphogenesis-chunks to restart Stage 6 chunking "
+                    "with new parameters."
+                )
     else:
         with open(meta_path, "w") as f:
             json.dump(expected_meta, f, ensure_ascii=False, indent=2)
@@ -5032,6 +5253,7 @@ def run_stage9a_arxiv_paper_hypergraphs(
     eprint_ok = 0
     eprint_missing = 0
     eprint_status = Counter()
+    eprint_status_examples = {}
 
     with open(out_path, "w", encoding="utf-8") as f:
         f.write("[\n")
@@ -5047,6 +5269,7 @@ def run_stage9a_arxiv_paper_hypergraphs(
                 )
                 estatus = e_meta.get("status", "unknown")
                 eprint_status[estatus] += 1
+                _record_eprint_diagnostic(eprint_status_examples, eid, e_meta)
                 if eprint_text:
                     full_text = eprint_text
                     eprint_ok += 1
@@ -5114,6 +5337,7 @@ def run_stage9a_arxiv_paper_hypergraphs(
         "eprint_text_used": eprint_ok,
         "eprint_text_missing": eprint_missing,
         "eprint_status_counts": dict(eprint_status),
+        "eprint_status_examples": eprint_status_examples,
     }
     if paper_hg_eprint_dir is not None and total and eprint_ok == 0:
         try:
@@ -7234,7 +7458,20 @@ def main():
         }
         write_json(outdir / "clusters.json", cluster_data)
         print(f"       Stage 4 done in {time.time()-t4:.0f}s")
-        mark_stage("clustering", "completed", n_clusters=int(n_clusters), n_noise=int(n_noise))
+        noise_rate = (n_noise / len(labels)) if labels else 0.0
+        health_gate(
+            "Stage 4",
+            bool(labels) and n_clusters == 0,
+            f"clustering produced zero clusters ({n_noise}/{len(labels)} noise, "
+            f"noise_rate={noise_rate:.1%})",
+        )
+        mark_stage(
+            "clustering",
+            "completed",
+            n_clusters=int(n_clusters),
+            n_noise=int(n_noise),
+            noise_rate=round(float(noise_rate), 4),
+        )
     else:
         print(f"\n[Stage 4/{n_stages}] Skipped")
         if args.skip_clustering:
@@ -7351,6 +7588,9 @@ def main():
                       f"abstract-fallback={stage5_stats['text_source_counts'].get('abstract', 0)}")
                 print(f"       Stage 5 eprint load status: "
                       f"{stage5_stats.get('eprint_status_counts', {})}")
+                examples = stage5_stats.get("eprint_status_examples") or {}
+                if examples:
+                    print(f"       Stage 5 eprint diagnostic samples: {list(examples)}")
             print(f"       Stage 5 done in {time.time()-t5:.0f}s")
             mark_stage(
                 "ner_scopes",
@@ -7358,6 +7598,7 @@ def main():
                 entities_processed=stage5_stats["entities_processed"],
                 text_source_counts=stage5_stats.get("text_source_counts", {}),
                 eprint_status_counts=stage5_stats.get("eprint_status_counts", {}),
+                eprint_status_examples=stage5_stats.get("eprint_status_examples", {}),
                 eprint_text_used=stage5_stats.get("eprint_text_used", 0),
                 eprint_text_missing=stage5_stats.get("eprint_text_missing", 0),
                 total_discourse_records=stage5_stats.get("total_discourse_records", 0),
@@ -7582,6 +7823,7 @@ def main():
             arm_counts = {"classical": 0, "llm": 0, "both": 0}
             text_source_counts = {"eprint": 0, "abstract": 0}
             eprint_status_counts = {}
+            eprint_status_examples = {}
             t_batch = time.time()
             llm_chunk_size = max(1, args.llm_batch_size * 8)
             pending_texts = []
@@ -7640,6 +7882,7 @@ def main():
                 eprint_status_counts[eprint_status] = (
                     eprint_status_counts.get(eprint_status, 0) + 1
                 )
+                _record_eprint_diagnostic(eprint_status_examples, eid, eprint_meta)
                 classical_hits = (
                     extract_techniques_classical(
                         paper_text,
@@ -7683,6 +7926,7 @@ def main():
                 "arm_counts": arm_counts,
                 "text_source_counts": text_source_counts,
                 "eprint_status_counts": eprint_status_counts,
+                "eprint_status_examples": eprint_status_examples,
             }
             write_stage_status(
                 outdir,
@@ -7700,6 +7944,8 @@ def main():
                   f"abstract-fallback={text_source_counts['abstract']}")
             if paper_eprint_path is not None:
                 print(f"       Eprint load status: {eprint_status_counts}")
+                if eprint_status_examples:
+                    print(f"       Eprint diagnostic samples: {list(eprint_status_examples)}")
             print(f"       Stage 5c done in {time.time()-t5c:.0f}s")
             mark_stage("technique_ner", "completed", **stage5c_record)
     else:
@@ -8011,7 +8257,9 @@ def main():
 
             text_source_counts = {"eprint": 0, "abstract": 0}
             eprint_status_counts = {}
+            eprint_status_examples = {}
             for entity, pair in zip(entities, pairs):
+                eid = entity["entity/id"]
                 _paper_text, text_source, eprint_meta = _paper_text_for(entity, pair)
                 text_source_counts[text_source] = (
                     text_source_counts.get(text_source, 0) + 1
@@ -8020,6 +8268,7 @@ def main():
                 eprint_status_counts[eprint_status] = (
                     eprint_status_counts.get(eprint_status, 0) + 1
                 )
+                _record_eprint_diagnostic(eprint_status_examples, eid, eprint_meta)
             _require_paper_eprint_usage(
                 "Stage 5d", text_source_counts, produced=bool(hypergraphs)
             )
@@ -8034,6 +8283,7 @@ def main():
                 "edge_provenance": edge_provenance,
                 "text_source_counts": text_source_counts,
                 "eprint_status_counts": eprint_status_counts,
+                "eprint_status_examples": eprint_status_examples,
                 "normalized_papers": paper_hg_metrics["normalized_papers"],
                 "normalization_rewrites": paper_hg_metrics["normalization_rewrites"],
                 "chunk_count": len(chunk_ranges),
@@ -8069,6 +8319,8 @@ def main():
                 )
             if paper_eprint_path is not None:
                 print(f"       Eprint load status: {eprint_status_counts}")
+                if eprint_status_examples:
+                    print(f"       Eprint diagnostic samples: {list(eprint_status_examples)}")
             print(f"       Stage 5d done in {time.time()-t5d:.0f}s")
             mark_stage("paper_hypergraph", "completed", **stage5d_record)
     else:
@@ -8104,7 +8356,7 @@ def main():
             len(pairs),
             args.llm_stage6_chunks_per_shard,
         ):
-            print("       Stage 6 chunks complete; reusing without loading LLM")
+            print("       Stage 6 chunks complete; reusing/reparsing without loading LLM")
             llm_pool = None
             pipe = tok = None
         else:
@@ -8413,6 +8665,9 @@ def main():
             print(f"       Eprint text coverage: {stage9a_stats.get('eprint_text_used', 0)}/"
                   f"{stage9a_stats.get('papers_processed', 0)} "
                   f"(missing={stage9a_stats.get('eprint_text_missing', 0)})")
+            examples = stage9a_stats.get("eprint_status_examples") or {}
+            if examples:
+                print(f"       Eprint diagnostic samples: {list(examples)}")
         geometry_source_path, geometry_source = _arxiv_geometry_source_path(outdir, hg_path)
         geometry_stats, geometry_path = write_geometry_artifact(
             geometry_source_path,

--- a/scripts/superpod-shard.py
+++ b/scripts/superpod-shard.py
@@ -384,17 +384,21 @@ def run_post_merge_stages(outdir: Path, graph_embed_dim: int,
     else:
         print(f"\n{log_prefix} Phase C skipped (no hypergraphs.json in merged output)")
 
-def detect_gpu_count():
-    """Detect number of available GPUs."""
+def visible_gpu_devices():
+    """Return GPU tokens this process is allowed to hand to shard workers."""
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible is not None:
+        return [token.strip() for token in visible.split(",") if token.strip()]
+
     try:
         result = subprocess.run(
-            ["nvidia-smi", "--query-gpu=name", "--format=csv,noheader"],
+            ["nvidia-smi", "--query-gpu=index", "--format=csv,noheader,nounits"],
             capture_output=True, text=True, timeout=10)
         if result.returncode == 0:
-            return len(result.stdout.strip().splitlines())
+            return [line.strip() for line in result.stdout.splitlines() if line.strip()]
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
-    return 0
+    return []
 
 
 def cmd_run(args):
@@ -421,9 +425,11 @@ def cmd_run(args):
     outdir = Path(args.output_dir)
     outdir.mkdir(parents=True, exist_ok=True)
 
-    # Detect GPUs for assignment
-    num_gpus = detect_gpu_count()
-    print(f"[run] {num_shards} shards, {num_gpus} GPUs detected")
+    # Detect GPUs for assignment. Respect CUDA_VISIBLE_DEVICES if a launcher has
+    # already narrowed the process to the Slurm-authorized allocation.
+    gpu_devices = visible_gpu_devices()
+    num_gpus = len(gpu_devices)
+    print(f"[run] {num_shards} shards, {num_gpus} GPUs visible")
     print(f"[run] CPU affinity: {_available_cpu_count()} cores; "
           f"LLM loader workers per shard: {args.llm_loader_workers}")
     print(f"[run] output: {outdir}")
@@ -462,10 +468,11 @@ def cmd_run(args):
         ]
         env = os.environ.copy()
         env["PYTHONUNBUFFERED"] = "1"
-        if num_gpus > 0:
-            env["CUDA_VISIBLE_DEVICES"] = str(i % num_gpus)
-        print(f"  shard {i}: CUDA_VISIBLE_DEVICES={i % num_gpus if num_gpus else 'none'} "
-              f"→ {shard_dirs[i]}")
+        shard_gpu = gpu_devices[i % num_gpus] if num_gpus else None
+        if shard_gpu is not None:
+            env["CUDA_VISIBLE_DEVICES"] = shard_gpu
+        print(f"  shard {i}: CUDA_VISIBLE_DEVICES={shard_gpu if shard_gpu is not None else 'none'} "
+              f"-> {shard_dirs[i]}")
         proc = subprocess.Popen(
             shard_cmd, env=env,
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,

--- a/src/futon6/arxiv_pattern_prompt.py
+++ b/src/futon6/arxiv_pattern_prompt.py
@@ -277,6 +277,8 @@ JSON output:"""
 
 _VALID_FAMILY_IDS = set(FAMILY_PARENTS)
 _INVALID_JSON_ESCAPE_RE = re.compile(r"\\(?![\"\\/bfnrtu])")
+_JSON_STRING_FIELD_TEMPLATE = r'"{field}"\s*:\s*"((?:\\.|[^"\\])*)"'
+_JSON_NUMERIC_FIELD_TEMPLATE = r'"{field}"\s*:\s*([0-9]+(?:\.[0-9]+)?)'
 
 
 def _json_loads_tolerating_tex_escapes(blob: str) -> tuple[dict | None, str | None]:
@@ -309,6 +311,50 @@ def _coerce_confidence(value, *, default: float = 0.0) -> float:
     return max(0.0, min(1.0, parsed))
 
 
+def _extract_json_string_field(text: str, field: str) -> str | None:
+    pattern = re.compile(_JSON_STRING_FIELD_TEMPLATE.format(field=re.escape(field)))
+    match = pattern.search(text)
+    if not match:
+        return None
+    try:
+        return json.loads(f'"{match.group(1)}"')
+    except json.JSONDecodeError:
+        return _INVALID_JSON_ESCAPE_RE.sub(r"\\\\", match.group(1))
+
+
+def _extract_json_numeric_field(text: str, field: str) -> float | None:
+    pattern = re.compile(_JSON_NUMERIC_FIELD_TEMPLATE.format(field=re.escape(field)))
+    match = pattern.search(text)
+    if not match:
+        return None
+    return _coerce_confidence(match.group(1))
+
+
+def _salvage_truncated_json_object(text: str) -> tuple[dict | None, str | None]:
+    """Recover useful Stage 3 fields from token-truncated JSON-like output.
+
+    The 8B local model can emit the requested object but stop mid-rationale
+    when the Stage 3 token budget is too small.  In that case the family and
+    leaf fields are often complete and more useful than dropping the row.
+    """
+    if "{" not in text:
+        return None, "no-json-object"
+    family = _extract_json_string_field(text, "family")
+    if family not in _VALID_FAMILY_IDS:
+        return None, f"invalid-family: {family!r}"
+    leaf = _extract_json_string_field(text, "leaf") or "uncertain"
+    rationale = _extract_json_string_field(text, "rationale") or ""
+    return {
+        "family": family,
+        "leaf": leaf,
+        "family_confidence": _extract_json_numeric_field(text, "family_confidence"),
+        "leaf_confidence": _extract_json_numeric_field(text, "leaf_confidence"),
+        "rationale": rationale,
+        "collapsed": None,
+        "_salvaged_from_truncated_json": True,
+    }, None
+
+
 def parse_arxiv_pattern_response(
     raw: str,
     taxonomy: Optional[PaperShapeTaxonomy] = None,
@@ -329,15 +375,21 @@ def parse_arxiv_pattern_response(
     brace_start = text.find("{")
     brace_end = text.rfind("}")
     if brace_start < 0 or brace_end < brace_start:
-        return {"ok": False, "error": "no-json-object", "raw_excerpt": text[:200]}
-    blob = text[brace_start:brace_end + 1]
-    obj, json_error = _json_loads_tolerating_tex_escapes(blob)
-    if obj is None:
-        return {
-            "ok": False,
-            "error": json_error or "json-not-object",
-            "raw_excerpt": blob[:200],
-        }
+        obj, salvage_error = _salvage_truncated_json_object(text)
+        if obj is None:
+            return {"ok": False, "error": salvage_error or "no-json-object", "raw_excerpt": text[:200]}
+        blob = text[brace_start:] if brace_start >= 0 else text
+    else:
+        blob = text[brace_start:brace_end + 1]
+        obj, json_error = _json_loads_tolerating_tex_escapes(blob)
+        if obj is None:
+            obj, salvage_error = _salvage_truncated_json_object(blob)
+            if obj is None:
+                return {
+                    "ok": False,
+                    "error": json_error or salvage_error or "json-not-object",
+                    "raw_excerpt": blob[:200],
+                }
 
     family = obj.get("family", "")
     leaf = obj.get("leaf", "")
@@ -369,6 +421,9 @@ def parse_arxiv_pattern_response(
                     obj.get("rationale", "") or "LLM omitted collapsed metadata."
                 ),
             }
+
+    if obj.get("_salvaged_from_truncated_json"):
+        warnings.append("truncated-json-salvaged")
 
     return {
         "ok": True,

--- a/tests/test_arxiv_pattern_prompt.py
+++ b/tests/test_arxiv_pattern_prompt.py
@@ -240,6 +240,21 @@ class TestResponseParser(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertIn("\\mathbb", result["rationale"])
 
+    def test_truncated_json_response_is_salvaged_when_family_and_leaf_are_complete(self):
+        raw = (
+            '{'
+            '"family": "math-strategy/characterization-result",'
+            '"leaf": "math-informal/structural-characterization",'
+            '"family_confidence": 0.9,'
+            '"leaf_confidence": 0.8,'
+            '"rationale": "The paper provides a characterization of n-categories'
+        )
+        result = parse_arxiv_pattern_response(raw)
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["family"], "math-strategy/characterization-result")
+        self.assertEqual(result["leaf"], "math-informal/structural-characterization")
+        self.assertIn("truncated-json-salvaged", result["warnings"])
+
     def test_no_json_in_response(self):
         result = parse_arxiv_pattern_response("Sorry, I cannot answer.")
         self.assertFalse(result["ok"])

--- a/tests/test_stage6_json_parser.py
+++ b/tests/test_stage6_json_parser.py
@@ -50,6 +50,25 @@ def test_stage6_parser_repairs_trailing_comma_and_unclosed_object():
     assert "parse_error" not in parsed
 
 
+def test_stage6_parser_salvages_truncated_jsonish_top_level_object():
+    mod = _load_superpod_job()
+    raw = (
+        "Here is the analysis:\n\n"
+        "{\n"
+        "\"xiang_form\": \"integral operators $\\bS_p$ and $\\mathsf{C}$\",\n"
+        "\"xiang_salience\": \"understand boundedness of a specific operator\",\n"
+        "\"arrow_constraint\": \"identify the relation among a, b, and p\",\n"
+        "\"quality\": {\"form\": \"good\", \"salience\": \"good\", \"arrow\": \"good\"},\n"
+        "\"situation_S\": \"A researcher needs a boundedness criterion.\",\n"
+        "\"roundtrip_check\": \"Yes, the situation naturally produces the question.\""
+    )
+    parsed = mod._parse_json_object_response(raw)
+    assert parsed["xiang_form"] == "integral operators $\\bS_p$ and $\\mathsf{C}$"
+    assert parsed["quality"]["arrow"] == "good"
+    assert parsed["_jsonish_salvage"]["reason"] == "stage6-truncated-or-json-escape-repair"
+    assert "parse_error" not in parsed
+
+
 def test_stage6_parser_accepts_python_literal_dict():
     mod = _load_superpod_job()
     raw = (
@@ -94,6 +113,23 @@ def test_stage6_result_marks_distinct_slots_ok():
     assert result["reason"] is None
     assert result["collapsed"] is False
     assert result["slot_distinctness"]["status"] == "distinct"
+
+
+def test_stage6_result_marks_salvaged_truncated_output_ok():
+    mod = _load_superpod_job()
+    raw = (
+        "{"
+        "\"xiang_form\":\"integral operator $\\mathsf{C}$\","
+        "\"xiang_salience\":\"understand boundedness in Schatten classes\","
+        "\"arrow_constraint\":\"find the exponent relation needed for boundedness\","
+        "\"quality\":{\"form\":\"good\",\"salience\":\"good\",\"arrow\":\"good\"},"
+        "\"situation_S\":\"A researcher studies an integral operator on a Hilbert space.\","
+        "\"roundtrip_check\":\"Yes, the situation naturally asks for the boundedness criterion.\""
+    )
+    result = mod._build_stage6_result("arxiv-2b", 88, raw)
+    assert result["status"] == "ok"
+    assert result["salvage"]["reason"] == "stage6-truncated-or-json-escape-repair"
+    assert "\\mathsf{C}" in result["analysis"]["xiang_form"]
 
 
 def test_stage6_result_flags_slot_collapse_for_clarification():

--- a/tests/test_superpod_job_smoke.py
+++ b/tests/test_superpod_job_smoke.py
@@ -495,6 +495,27 @@ def test_structure_seed_match_rejects_when_prior_not_subsequence():
     assert mod._match_structure_seed_signature(new, priors) is None
 
 
+def test_eprint_loader_reports_unusable_candidate_attempts(tmp_path: Path):
+    root = Path(__file__).parent.parent
+    mod = _load_superpod_job_module(root)
+    eprints = tmp_path / "eprints"
+    eprints.mkdir()
+    (eprints / "math__0102067v1.bin").write_bytes(b"not a tar archive and not TeX")
+
+    text, meta = mod._load_eprint_text_for_entity(
+        eprints,
+        "arxiv-math/0102067v1",
+    )
+
+    assert text is None
+    assert meta["status"] == "unusable"
+    assert meta["candidates"]
+    assert {attempt["status"] for attempt in meta["attempts"]} >= {
+        "tar-read-error",
+        "plain-text-probe-no-tex",
+    }
+
+
 def test_superpod_job_ct_pipeline_smoke(tmp_path: Path):
     root = Path(__file__).parent.parent
     outdir = tmp_path / "superpod-out"
@@ -1028,7 +1049,8 @@ def test_stage3_existing_arxiv_chunks_reparse_when_parser_version_changes(tmp_pa
         "total_pairs": 1,
         "chunks_per_shard": 1,
         "effective_chunks": 1,
-        "max_new_tokens": 192,
+        "max_new_tokens": 64,
+        "parse_version": "arxiv-paper-shapes-v2",
     }
     (chunk_dir / "meta.json").write_text(
         json.dumps(old_meta, indent=2) + "\n",
@@ -1086,8 +1108,80 @@ def test_stage3_existing_arxiv_chunks_reparse_when_parser_version_changes(tmp_pa
     assert results[0]["status"] == "ok"
     assert "\\mathbb" in results[0]["rationale"]
     meta = json.loads((chunk_dir / "meta.json").read_text(encoding="utf-8"))
-    assert meta["parse_version"] == "arxiv-paper-shapes-v2"
+    assert meta["parse_version"] == "arxiv-paper-shapes-v3"
     merged = json.loads((outdir / "pattern-tags.json").read_text(encoding="utf-8"))
+    assert merged[0]["status"] == "ok"
+
+
+def test_stage6_existing_chunks_reparse_when_parser_version_changes(tmp_path: Path):
+    root = Path(__file__).parent.parent
+    module = _load_superpod_job_module(root)
+    outdir = tmp_path / "arxiv-out"
+    chunk_dir = outdir / "stage6-reverse-morphogenesis-chunks"
+    chunk_dir.mkdir(parents=True)
+    old_meta = {
+        "version": 2,
+        "total_pairs": 1,
+        "chunks_per_shard": 1,
+        "effective_chunks": 1,
+    }
+    (chunk_dir / "meta.json").write_text(
+        json.dumps(old_meta, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    raw = (
+        "{"
+        "\"xiang_form\":\"integral operator $\\mathsf{C}$\","
+        "\"xiang_salience\":\"understand boundedness in Schatten classes\","
+        "\"arrow_constraint\":\"find the exponent relation needed for boundedness\","
+        "\"quality\":{\"form\":\"good\",\"salience\":\"good\",\"arrow\":\"good\"},"
+        "\"situation_S\":\"A researcher studies an integral operator on a Hilbert space.\","
+        "\"roundtrip_check\":\"Yes, the situation naturally asks for the boundedness criterion.\""
+    )
+    (chunk_dir / "chunk-000.json").write_text(
+        json.dumps(
+            [
+                {
+                    "entity_id": "arxiv-math/0212293",
+                    "question_id": 947844714,
+                    "status": "failed",
+                    "reason": "stage6-missing-required-keys",
+                    "analysis": {"form": "good", "salience": "good", "arrow": "good"},
+                    "raw": raw,
+                }
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    class FailIfCalledPool:
+        def run_stage6(self, items, batch_size):
+            raise AssertionError("Stage 6 LLM should not rerun existing chunks")
+
+    pairs = [
+        SimpleNamespace(
+            question=SimpleNamespace(id=947844714, title="A toy paper", body_text="abstract"),
+            answer=SimpleNamespace(body_text="abstract"),
+        )
+    ]
+    entities = [{"entity/id": "arxiv-math/0212293"}]
+    results = module.run_stage6_reverse_morphogenesis_chunked(
+        pairs,
+        entities,
+        outdir,
+        pipe=None,
+        tokenizer=None,
+        batch_size=1,
+        chunks_per_shard=1,
+        llm_pool=FailIfCalledPool(),
+    )
+
+    assert results[0]["status"] == "ok"
+    assert results[0]["salvage"]["reason"] == "stage6-truncated-or-json-escape-repair"
+    meta = json.loads((chunk_dir / "meta.json").read_text(encoding="utf-8"))
+    assert meta["parse_version"] == "reverse-morphogenesis-v3"
+    merged = json.loads((outdir / "reverse-morphogenesis.json").read_text(encoding="utf-8"))
     assert merged[0]["status"] == "ok"
 
 


### PR DESCRIPTION
## Summary

- Add a superpod GPU policy helper that resolves the current Slurm job allocation through mfuton and exports only the allowed GPU IDs.
- Wire the CT/arXiv superpod launchers to use the resolved GPU count for embedding and LLM worker counts instead of assuming the whole node.
- Improve CT run robustness by salvaging truncated Stage 3 and Stage 6 JSON-ish LLM outputs and reparsing stale chunks after parser-version changes.
- Preserve more diagnostic detail for unusable eprint candidates so failed CT stages can be debugged from logs.

## Verification

- `bash -n scripts/mfuton-superpod-gpu-policy.sh scripts/handoff-superpod-all.sh scripts/handoff-superpod-gpu-backfill.sh scripts/run-arxiv-handoff.sh scripts/setup-ct-run.sh`
- `FUTON3_LIBRARY=/users/rjmeyers/darktower/futon3/library PYTHONPATH=src /users/rjmeyers/.conda/envs/codex/bin/python -m pytest -q tests/test_arxiv_pattern_prompt.py::TestResponseParser::test_truncated_json_response_is_salvaged_when_family_and_leaf_are_complete tests/test_stage6_json_parser.py tests/test_superpod_job_smoke.py::test_eprint_loader_reports_unusable_candidate_attempts tests/test_superpod_job_smoke.py::test_stage3_existing_arxiv_chunks_reparse_when_parser_version_changes tests/test_superpod_job_smoke.py::test_stage6_existing_chunks_reparse_when_parser_version_changes tests/test_shard.py`

## Notes

- The initial bare `python3 -m pytest ...` probe failed because the system Python on the superpod does not provide pytest. Verification above used the Codex environment.
- The full three-file pytest sweep was interrupted because it entered longer integration-style smoke tests; the focused checks above cover the changed code paths and passed.
